### PR TITLE
Fix for windows and remove Fuzzy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Project Link: https://urban-labs.github.io/namematch/
 pip install namematch 
 ```
 
+Name Match has been tested using Python 3.7 and 3.8, on both linux and Windows systems. Note, Name Match will not currently work using Python 3.9 on Windows because of the dependency on NMSLIB.
+
+
 ### Reference
 
 * [Examples](https://github.com/urban-labs/namematch/tree/main/examples)

--- a/examples/python_usage/link_data.py
+++ b/examples/python_usage/link_data.py
@@ -103,12 +103,15 @@ config_dict = {
 
 }
 
-# Instantiate NameMatcher objet
-nm = NameMatcher(
-    config=config_dict
-)
 
-# Run Name Match
-nm.run()
+if __name__ == "__main__":
 
-# Once the process completes, the output will be in the output/ directory
+    # Instantiate NameMatcher objet
+    nm = NameMatcher(
+        config=config_dict
+    )
+
+    # Run Name Match
+    nm.run()
+
+    # Once the process completes, the output will be in the output/ directory

--- a/namematch/block.py
+++ b/namematch/block.py
@@ -81,7 +81,7 @@ class Block(NamematchBase):
             output_files.append(os.path.join(temp_dir, 'uncovered_pairs.csv'))
         return output_files
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def main(self, **kw):
         '''Generate the candidate-pairs list using the blocking scheme outlined in the config.'''
@@ -156,7 +156,7 @@ class Block(NamematchBase):
         if self.enable_lprof:
             self.write_line_profile_stats(profile.line_profiler)
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def split_last_names(self, df, last_name_column, blocking_scheme, **kw):
         '''Expand the processed all-names file to handle double last names (e.g. SAM SMITH-BROWN
@@ -215,7 +215,7 @@ class Block(NamematchBase):
 
         return df
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def convert_all_names_to_blockstring_info(self, an, absval_col, params, **kw):
         '''Create a table with information about blockstrings. If the split_names parameter is True,
@@ -348,7 +348,7 @@ class Block(NamematchBase):
 
         return nn_string_info_to_query, nn_strings_to_query, shingles_to_query
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def generate_shingles_matrix(
             self,
@@ -402,7 +402,7 @@ class Block(NamematchBase):
 
         return shingles_matrix
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def load_main_index(self, index_file, **kw):
         '''Load the main index, which is reusable over time as data is added incrementally.
@@ -419,7 +419,7 @@ class Block(NamematchBase):
 
         return ix
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def generate_index(
             self,
             nn_strings,
@@ -462,7 +462,7 @@ class Block(NamematchBase):
 
         return ix
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def get_indices(self, params, all_nn_strings, og_blocking_index_file, **kw):
         '''Wrapper function coordinating the creation and/or loading of the nmslib indices.
@@ -531,7 +531,7 @@ class Block(NamematchBase):
 
         return main_index, main_index_nn_strings, second_index, second_index_nn_strings
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def generate_candidate_pairs(
         self,
@@ -685,7 +685,7 @@ class Block(NamematchBase):
 
         return cand_pair_df
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def compute_cosine_sim(self, blockstrings_in_pairs, pairs_df, shingles_matrix, **kw):
         '''Fast cosine similarity computation using the shingles matrix.
 
@@ -736,7 +736,7 @@ class Block(NamematchBase):
 
         return pair_cos
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def evaluate_blocking(self, cp_df, tp_df, blocking_scheme, **kw):
         '''The evaluate_blocking function computes the pair completeness metrics to

--- a/namematch/cluster.py
+++ b/namematch/cluster.py
@@ -122,7 +122,7 @@ class Cluster(NamematchBase):
     def output_files(self):
         return [self.cluster_assignments, self.edges]
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def main(self, **kw):
         '''Read the record pairs with high probability of matching and connect them in a way
@@ -322,7 +322,7 @@ class Cluster(NamematchBase):
 
         return True
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def get_initial_clusters(self, must_links_df, an_df, eid_col, **kw):
         '''Use must links (ground truth and/or a previous run) to create the
@@ -427,12 +427,12 @@ class Cluster(NamematchBase):
         gc.collect()
         return clusters, cluster_assignments, original_cluster_ids
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def save_df_to_disk(self, df):
         table = pa.Table.from_pandas(df)
         pq.write_table(table, self.edges)
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def get_potential_edges(self, potential_edges_files, flipped0_edges_file, gt_1s_df, cluster_logic, cluster_info, uid_cols, eid_col, **kw):
         '''
@@ -530,7 +530,7 @@ class Cluster(NamematchBase):
         del valid_potential_edges_df
         gc.collect()
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def load_cluster_info(self, all_names_file, uid_cols, eid_col, cluster_logic, **kw):
         '''Read in the all_names information needed for cluster constraint checking. Columns
@@ -601,12 +601,12 @@ class Cluster(NamematchBase):
             cluster_info[col] = cluster_info[col].replace('', np.nan)
         return cluster_info
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def get_ci_ix_map(self, cluster_info):
         ci_ix_map = dict(zip(cluster_info.index.tolist(), range(len(cluster_info))))
         return ci_ix_map
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def cluster_potential_edges(self, clusters, cluster_assignments, original_cluster_ids,
                 cluster_info, cluster_logic, uid_cols, eid_col, **kw):

--- a/namematch/comparison_functions.py
+++ b/namematch/comparison_functions.py
@@ -1,6 +1,5 @@
 import editdistance
-import fuzzy
-import jellyfish._jellyfish as jf
+import jellyfish
 import logging
 import numpy as np
 import pandas as pd
@@ -192,15 +191,15 @@ def compare_strings(df, varname):
     features_df.loc[df.msng == 0, varname + '_exact_match_1st2nd3rd'] = \
             (df[col1].str.slice(0, 3) == df[col2].str.slice(0, 3)).astype(float)
 
-    df.loc[df.msng == 0, 'soundex_col_1'] = np.vectorize(jf.soundex, otypes=['str'])(
+    df.loc[df.msng == 0, 'soundex_col_1'] = np.vectorize(jellyfish.soundex, otypes=['str'])(
             df[df.msng == 0][col1])
-    df.loc[df.msng == 0, 'soundex_col_2'] = np.vectorize(jf.soundex, otypes=['str'])(
+    df.loc[df.msng == 0, 'soundex_col_2'] = np.vectorize(jellyfish.soundex, otypes=['str'])(
             df[df.msng == 0][col2])
     features_df[varname + '_soundex'] = (df.soundex_col_1 == df.soundex_col_2).astype(int)
 
-    df.loc[df.valid_nysiis == 1, 'nysiis_col_1'] = np.vectorize(fuzzy.nysiis, otypes=['str'])(
+    df.loc[df.valid_nysiis == 1, 'nysiis_col_1'] = np.vectorize(jellyfish.nysiis, otypes=['str'])(
             df[df.valid_nysiis == 1][col1].values)
-    df.loc[df.valid_nysiis == 1, 'nysiis_col_2'] = np.vectorize(fuzzy.nysiis, otypes=['str'])(
+    df.loc[df.valid_nysiis == 1, 'nysiis_col_2'] = np.vectorize(jellyfish.nysiis, otypes=['str'])(
             df[df.valid_nysiis == 1][col2].values)
     features_df[varname + '_nysiis'] = (df.nysiis_col_1 == df.nysiis_col_2).astype(int)
 

--- a/namematch/fit_model.py
+++ b/namematch/fit_model.py
@@ -105,7 +105,7 @@ class FitModel(NamematchBase):
             os.path.join(self.data_rows_dir, dr_file) for dr_file in os.listdir(self.data_rows_dir)
         ]
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def main(self, **kw):
         '''Train and evaluate random foreset model(s). Depending on the settings, this might involved
@@ -231,7 +231,7 @@ class FitModel(NamematchBase):
                 self.write_line_profile_stats(profile.line_profiler)
 
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def fit_model(self, df, vars_to_exclude, outcome, weights=None, n_jobs=1, **kw):
         '''Fit random forest model.
 
@@ -460,7 +460,7 @@ class FitModel(NamematchBase):
         return train_df, eval_df, prob_match_train
 
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def find_valid_training_records(self, an, an_match_criteria):
         '''Identify records that meet the all-names criteria for training data.
 

--- a/namematch/generate_data_rows.py
+++ b/namematch/generate_data_rows.py
@@ -44,7 +44,7 @@ class GenerateDataRows(NamematchBase):
     def output_files(self):
         return [os.path.join(self.output_dir, f'data_rows_{i}.parquet') for i in range(self.params.num_workers)]
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def main(self, **kw):
         '''Take candidate pairs and merge on the all-names records (twice) to get a dataset at the
         record pair level. Compute distance metrics between the records in the pair -- these are the
@@ -117,7 +117,7 @@ class GenerateDataRows(NamematchBase):
         if self.enable_lprof:
             self.write_line_profile_stats(profile.line_profiler)
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def generate_name_probabilities_object(self, an, fn_col=None, ln_col=None, **kw):
         '''The generate_name_probabilites function uses a list of names (from all_names
         file) and creates an object containing queryable probability
@@ -147,7 +147,7 @@ class GenerateDataRows(NamematchBase):
 
         return np_object
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def find_valid_training_records(self, an, an_match_criteria, **kw):
 
         an['meets_match_criteria'] = 1
@@ -320,7 +320,7 @@ class GenerateDataRows(NamematchBase):
 
         return data_rows_df
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def generate_data_row_files(
                 self, params, schema, an, cp_df, name_probs,

--- a/namematch/generate_must_links.py
+++ b/namematch/generate_must_links.py
@@ -37,7 +37,7 @@ class GenerateMustLinks(NamematchBase):
             self.must_links
         ]
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def main(self, **kw):
         '''Generate the list of must-link pairs using UniqueID and ExistingID info .
 
@@ -109,7 +109,7 @@ class GenerateMustLinks(NamematchBase):
 
         return an[an.has_ml_var == 1]
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     @profile
     def get_must_links(self, ml_var_df, uid_vars_list, eid_vars_list, **kw):
         '''Expand the list of records with must-link information to pairs of records

--- a/namematch/generate_output.py
+++ b/namematch/generate_output.py
@@ -81,7 +81,7 @@ class GenerateOutput(NamematchBase):
 
         self.stats_dict['end'] = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def create_allnames_clusterid_file(self, all_names_file, cluster_assignments, cleaned_col_names, **kw):
         '''Create all-names-with-clusterid dataframe.
 
@@ -114,7 +114,7 @@ class GenerateOutput(NamematchBase):
 
         return all_names
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def output_clusterid_files(self, data_files, cluster_assignments, output_dir, output_file_uuid=None, **kw):
         '''For each input file, construct a matching output file that has the
         cluster_id column, and write it.

--- a/namematch/generate_report.py
+++ b/namematch/generate_report.py
@@ -49,7 +49,7 @@ class GenerateReport(NamematchBase):
             html_exporter.exclude_input_prompt = True
             html_exporter.exclude_output_prompt = True
             html_data, resources = html_exporter.from_filename(temp_output_notebook)
-            with open(self.report_file, 'w') as f:
+            with open(self.report_file, 'w', encoding='utf-8', errors='ignore') as f:
                 f.write(html_data)
 
             logger.info(f"The matching report is created at {self.report_file}")

--- a/namematch/process_input_data.py
+++ b/namematch/process_input_data.py
@@ -46,7 +46,7 @@ class ProcessInputData(NamematchBase):
             self.all_names_file
         ]
 
-    @log_runtime_and_memory
+    # @log_runtime_and_memory
     def main(self, **kw):
         '''Follow the instructions in the schema and params objects to build the all-names file from
         the raw input file(s).

--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -7,7 +7,6 @@ pyyaml==5.1
 ruamel.yaml==0.17.17
 line_profiler==3.3.1
 jellyfish==0.8.9
-Fuzzy==1.2.2
 pyjarowinkler==1.8
 editdistance==0.6.0
 street-address==0.4.0


### PR DESCRIPTION
When having issues installing Fuzzy on windows, we realized the Fuzzy package is no longer maintained. Since we only use Fuzzy to compute NYSIIS metrics, and we already rely on another package that can do this (jellyfish), we decided to remove the Fuzzy dependency. 

This PR also makes a small improvement to the python usage example that allows it to run on Windows (adding `if name == '__main__':` syntax),  