### PR TITLE
Enhanced matching report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project does not yet follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Cluster rejection-reasons hook.** Users can declare a module-level
+  `rejection_reasons` counter (a `Counter` or `defaultdict(int)`) in their
+  custom constraints file and increment it from inside `is_valid_cluster()`
+  before each `return False`. Name Match picks the counter up after clustering
+  and renders a sorted (reason, count, %) table in the matching report.
+  Opt-in: constraints modules without the counter behave exactly as before.
+  See `docs/source/match_setup.rst` ("Tracking rejection reasons") and
+  `examples/clue_constraints.py` for a worked example.
+- **NMSLIB filtering-efficiency logging in `Block`.** After the candidate-query
+  loop, one summary block reports total raw neighbors from NMSLIB, candidates
+  before and after dedup, acceptance rate, avg neighbors-per-query, and avg
+  final-candidates-per-query. The first batch of the main index also writes
+  raw `near_neighbors` to `details/near_neighbors_raw.parquet` for one-time
+  debugging.
+- **`max_demographic_values` parameter** in `evaluate_predictions()`. Caps the
+  number of unique values per categorical demographic variable (default 10),
+  skipping high-cardinality variables (e.g., zip code) at universe
+  construction. Also gates per-demographic-subgroup INFO logs so run logs show
+  clean base-universe metrics; stats are still saved for the matching report.
+- **`examples/clue_constraints.py`** tracked as a reference implementation of
+  the `rejection_reasons` hook, with four cluster-level constraints (size,
+  dob uniqueness, age range, name+dob combos) and a `print_rejection_summary`
+  helper.
+
+### Changed
+
+- **`FitModel` uses chunked Parquet reads.** `get_train_eval_data()` now reads
+  data rows via `pyarrow.ParquetFile.iter_batches(batch_size=10M)` with
+  per-batch filter/sample/concat, replacing two full-frame
+  `load_parquet_list()` calls. Avoids OOM on large datasets (validated at 7M
+  defendant records, 11 GB data_rows parquet). No behavior change beyond
+  memory profile.
+
+### Fixed
+
+- **`blocking_scheme` cosine-distance key typo.** Truncation of >2 cosine
+  variables previously reassigned the wrong key (`'variable'` instead of
+  `'variables'`), leaving the over-2 list intact and adding a stray key. The
+  warning still fires; the slice now actually takes effect.
+- **`reformat_dict()` handles nested dicts and numpy scalar types.** Previously
+  only the top level of the dict was walked, so nested stats trees containing
+  `np.integer` / `np.floating` values failed yaml dump in some environments.

--- a/docs/source/match_setup.rst
+++ b/docs/source/match_setup.rst
@@ -224,6 +224,19 @@ If there is no special logic you wish to encode, this function should simply ret
 
 Notice the optional ``phat`` parameter being passed into ``is_valid_cluster()``. This float is the prediction from the model, or the probability that the two records belong to the same person. This information might be useful if, for example, you want to apply looser constraints to links the model is more confident in.
 
+**A quick note about missing values:** In the dataframes passed to ``is_valid_link()`` and ``is_valid_cluster()``, missing values will be encoded as ``np.NaN`` for ID columns, numeric columns, and date columns. Missing values will be encoded as empty strings ("") for string/object columns. For control over the data type each column is represetned as, see the section on the ``get_columns_used`` function below. 
+
+**A quick note about variable names:** Notice how we reference a column called ``school_id`` in the ``is_valid_cluster`` example above. This is made possible via the Name Match config file where we defined a variable called `school_id`, like so:
+::
+
+    - 'name' : 'school_id'
+      'compare_type' : null 
+      'dataset_1_col' : 'SchoolID'
+      'dataset_2_col' : 'SCHOOL_IDENTIFIER'
+
+This then allows us to access the ``school_id`` field in ``is_valid_link`` and ``is_valid_cluster``. Also note that by specifiying a ``null`` compare type, we have indicated that we only want the field to be used in constraint-checking (**not in the prediction model**).
+
+
 Tracking rejection reasons (optional)
 +++++++++++++++++++++++++++++++++++++
 
@@ -258,19 +271,6 @@ A few caveats:
 * The counter is module-level state and is not reset between ``NameMatcher.run()`` calls within the same Python process. Add ``rejection_reasons.clear()`` somewhere in your module setup if you need per-run isolation.
 * The counter is not thread-safe. Clustering is currently single-threaded, but be aware if you adapt Name Match's internals to parallelize clustering.
 * Today only ``is_valid_cluster`` rejections are tracked. ``is_valid_link`` rejections are counted but not categorized.
-
-**A quick note about missing values:** In the dataframes passed to ``is_valid_link()`` and ``is_valid_cluster()``, missing values will be encoded as ``np.NaN`` for ID columns, numeric columns, and date columns. Missing values will be encoded as empty strings ("") for string/object columns. For control over the data type each column is represetned as, see the section on the ``get_columns_used`` function below. 
-
-**A quick note about variable names:** Notice how we reference a column called ``school_id`` in the ``is_valid_cluster`` example above. This is made possible via the Name Match config file where we defined a variable called `school_id`, like so:
-::
-
-    - 'name' : 'school_id'
-      'compare_type' : null 
-      'dataset_1_col' : 'SchoolID'
-      'dataset_2_col' : 'SCHOOL_IDENTIFIER'
-
-This then allows us to access the ``school_id`` field in ``is_valid_link`` and ``is_valid_cluster``. Also note that by specifiying a ``null`` compare type, we have indicated that we only want the field to be used in constraint-checking (**not in the prediction model**).
-
 
 Additional user-defined functions
 ##################################

--- a/docs/source/match_setup.rst
+++ b/docs/source/match_setup.rst
@@ -224,6 +224,41 @@ If there is no special logic you wish to encode, this function should simply ret
 
 Notice the optional ``phat`` parameter being passed into ``is_valid_cluster()``. This float is the prediction from the model, or the probability that the two records belong to the same person. This information might be useful if, for example, you want to apply looser constraints to links the model is more confident in.
 
+Tracking rejection reasons (optional)
++++++++++++++++++++++++++++++++++++++
+
+By default, Name Match's clustering step tracks a single count of how many candidate merges were rejected by ``is_valid_cluster()`` (``n_invalid_clusters`` in the stats). If your constraint function has more than one rule, you may want to know which rule rejected each merge — for example, to tune thresholds or to confirm that an unused rule is actually firing.
+
+To opt into this, declare a module-level ``rejection_reasons`` counter (a ``Counter`` or ``defaultdict(int)``) in your constraints file and increment it before each ``return False`` with a string label describing the reason. After clustering completes, Name Match looks for this attribute on your module and, if present, surfaces a sorted (reason, count, percentage) table in the matching report.
+
+**Example:**
+::
+
+    from collections import defaultdict
+
+    # Module-level counter — Name Match reads this after clustering
+    rejection_reasons = defaultdict(int)
+
+    def is_valid_cluster(cluster, phat=None):
+
+        if cluster["school_id"].nunique() > 5:
+            rejection_reasons['too_many_schools_>5'] += 1
+            return False
+
+        if cluster["age"].max() - cluster["age"].min() > 3:
+            rejection_reasons['age_range_>3_years'] += 1
+            return False
+
+        return True
+
+The labels are free-form strings of your choosing. They appear in the **Cluster Rejection Reasons** section of ``matching_report.html``. If you omit the ``rejection_reasons`` declaration entirely, nothing breaks — the report's rejection-reasons section simply shows "no rejections recorded". See `examples/clue_constraints.py <https://github.com/urban-labs/namematch/blob/master/examples/clue_constraints.py>`_ for a complete working file.
+
+A few caveats:
+
+* The counter is module-level state and is not reset between ``NameMatcher.run()`` calls within the same Python process. Add ``rejection_reasons.clear()`` somewhere in your module setup if you need per-run isolation.
+* The counter is not thread-safe. Clustering is currently single-threaded, but be aware if you adapt Name Match's internals to parallelize clustering.
+* Today only ``is_valid_cluster`` rejections are tracked. ``is_valid_link`` rejections are counted but not categorized.
+
 **A quick note about missing values:** In the dataframes passed to ``is_valid_link()`` and ``is_valid_cluster()``, missing values will be encoded as ``np.NaN`` for ID columns, numeric columns, and date columns. Missing values will be encoded as empty strings ("") for string/object columns. For control over the data type each column is represetned as, see the section on the ``get_columns_used`` function below. 
 
 **A quick note about variable names:** Notice how we reference a column called ``school_id`` in the ``is_valid_cluster`` example above. This is made possible via the Name Match config file where we defined a variable called `school_id`, like so:

--- a/examples/clue_constraints.py
+++ b/examples/clue_constraints.py
@@ -1,0 +1,132 @@
+import math
+import numpy as np
+import pandas as pd
+import editdistance
+from collections import defaultdict
+
+# Global counter to track cluster rejection reasons
+rejection_reasons = defaultdict(int)
+
+
+def is_valid_link(predicted_links_df):
+    '''Check if two records would form a valid link. For this default version, 
+    it simply returns True.
+
+    Args: 
+        predicted_links_df (pd.DataFrame): info on predicted links (record pairs)
+            ================      =======================================================
+            record_id_1           unique record identifier (for first in pair)
+            record_id_2           unique record identifier (for second in pair)
+            phat                  predicted probability of a record pair being a match
+            original_order        original ordering 1-N (useful so gt is always on top of phat=1 cases)
+            <other_cols>          columns from all-names that are required for constraint checking (will have _1 and _2 versions)
+            ================      =======================================================
+
+    Returns: 
+        boolean or boolean pd.Series: True for default version
+    '''
+    df = predicted_links_df
+    df['valid'] = True
+        
+    return df.valid
+
+
+def is_valid_cluster(cluster, phat):
+    '''Check if a proposed cluster is valid. For this default version,
+    it simply returns True. The information you'll have access to for the
+    cluster's records is determined by the column(s) specified in `get_columns_used`.
+
+    Args:
+        cluster (pd.DataFrame): all-names file (relevant columns only) records for the proposed cluster
+        phat (float): phat value of the proposed link
+
+    Returns:
+        bool: True for default version
+    '''
+
+    # This prevents clusters that are larger than 300 records
+    # Change this according to your expectations
+    if cluster.shape[0] > 300:
+        rejection_reasons['too_many_records_>300'] += 1
+        return False
+
+    # This is saying that there can only be 5 unique birthdates in a cluster
+    # Probably want to change this or get rid of it for yours
+    if cluster.dob.nunique()>5:
+        rejection_reasons['too_many_unique_dobs_>5'] += 1
+        return False
+
+    # This is saying that the maximum difference in age in a cluster is 3
+    if cluster.age.astype(int).max() - cluster.age.astype(int).min() > 3:
+        rejection_reasons['age_range_>3_years'] += 1
+        return False
+
+    # Limit clusters to a maximum of 6 unique combinations of first_name, last_name, and dob
+    # This prevents over-merging of distinct individuals
+    if cluster[['first_name', 'last_name', 'dob']].drop_duplicates().shape[0] > 6:
+        rejection_reasons['too_many_name_dob_combos_>6'] += 1
+        return False
+
+    return True
+   
+
+def apply_link_priority(valid_links_df):
+    '''Adjust the order in which valid link will be considered for clustering. For the vast majority of 
+    runs, the default behavior -- sorting by descending phat, or P(match) -- is best. 
+
+    Args:
+        valid_links_df (pd.DataFrame): info on valid predicted links (record pairs)
+            ================      =======================================================
+            record_id_1           unique record identifier (for first in pair)
+            record_id_2           unique record identifier (for second in pair)
+            phat                  predicted probability of a record pair being a match
+            original_order        original ordering 1-N (useful so gt is always on top of phat=1 cases)
+            <other_cols>          columns from all-names that are required for constraint checking (will have _1 and _2 versions)
+            ================      =======================================================
+
+    Returns:
+        pd.DataFrame: same as input, with phat columns potentially adjusted
+    '''
+
+    valid_links_df = valid_links_df.sort_values(by=['phat', 'original_order'], ascending=[False, True])
+
+    return valid_links_df
+
+
+def get_columns_used():
+    '''The `get_columns_used()` function returns either the string "all" (default) or a
+    dictionary mapping the names of data fields needed for constraint checking to the data
+    type they should be read in as. This can be useful to limit memory consumption during the
+    clustering step (by only reading in the data fields only needed in cluster logic).
+
+    Special note: if you want something to be treated as a date, use
+    dtype "date" (will be converted to a valid pandas dtype internally).
+
+    Returns:
+        dict: empty for default version
+    '''
+
+    return "all"
+
+
+def print_rejection_summary():
+    '''Print a summary of cluster rejection reasons.
+
+    Call this after clustering completes to see breakdown of why clusters were rejected.
+    '''
+    print("\n" + "="*80)
+    print("CLUSTER REJECTION SUMMARY")
+    print("="*80)
+
+    if not rejection_reasons:
+        print("No clusters were rejected.")
+    else:
+        total = sum(rejection_reasons.values())
+        print(f"Total rejected clusters: {total:,}\n")
+
+        # Sort by count descending
+        for reason, count in sorted(rejection_reasons.items(), key=lambda x: x[1], reverse=True):
+            pct = 100.0 * count / total if total > 0 else 0
+            print(f"  {reason:.<45} {count:>8,} ({pct:>5.1f}%)")
+
+    print("="*80 + "\n")

--- a/examples/end_to_end_tutorial.ipynb
+++ b/examples/end_to_end_tutorial.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "4de7c21f",
    "metadata": {
     "toc": true
    },
@@ -12,6 +13,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "24d0592c",
    "metadata": {},
    "source": [
     "# Overview"
@@ -19,6 +21,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "17f9ba2d",
    "metadata": {},
    "source": [
     "This tutorial demonstrates how to use Name Match to link two datasets. It walks through step-by-step:\n",
@@ -33,6 +36,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "da0576ed",
    "metadata": {},
    "source": [
     "# Problem statement"
@@ -40,6 +44,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "816e5b3c",
    "metadata": {},
    "source": [
     "There is an upcoming election in Brazil, and reporters are starting to speculate about who will be running for various offices. You want to know which of these potential candidates have run for election in the past -- what position(s) they ran for when, who they ran against, etc. \n",
@@ -51,6 +56,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e1a589f4",
    "metadata": {},
    "source": [
     "# Setup"
@@ -58,6 +64,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "413dd707",
    "metadata": {},
    "source": [
     "Import packages and configure notebook settings"
@@ -66,6 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "730db55c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,6 +91,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5c89875a",
    "metadata": {},
    "source": [
     "# Load data"
@@ -91,6 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "23db8f05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,6 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "4ead5b13",
    "metadata": {},
    "outputs": [
     {
@@ -208,6 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "377f745e",
    "metadata": {},
    "outputs": [
     {
@@ -346,6 +358,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4aa7690a",
    "metadata": {},
    "source": [
     "# Does this linkage task meet the requirements of Name Match?"
@@ -353,6 +366,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d4a2b737",
    "metadata": {},
    "source": [
     "The requirements of Name Match are: \n",
@@ -362,6 +376,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b7fa3390",
    "metadata": {},
    "source": [
     "#### Does this task meet requirement #1?"
@@ -369,6 +384,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d38ddace",
    "metadata": {},
    "source": [
     "<font color='green'><b>Yes!</b></font> The `past_candidates` file, has a `candiate_id` field with non-null values."
@@ -377,6 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "63cc1387",
    "metadata": {},
    "outputs": [
     {
@@ -401,6 +418,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "625b3969",
    "metadata": {},
    "source": [
     "#### Does this task meet requirment #2? \n",
@@ -411,6 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "4b47ffca",
    "metadata": {},
    "outputs": [
     {
@@ -497,6 +516,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "224a03c9",
    "metadata": {},
    "source": [
     "When we count the number of unique names and dobs per `candidate_id` we see that not all values are 1. Meaning a candidate can appear multiple times with variations in the spelling of their name or recording of their dob information."
@@ -504,6 +524,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b98d11c2",
    "metadata": {},
    "source": [
     "This means that <font color='green'><b>Yes!</b></font> the second requriment of Name Match is met."
@@ -511,6 +532,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "230a7020",
    "metadata": {},
    "source": [
     "# Preparing the data for linkage"
@@ -518,6 +540,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3507fe9b",
    "metadata": {},
    "source": [
     "### Deciding which fields should be used to inform the match"
@@ -525,6 +548,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c54b3688",
    "metadata": {},
    "source": [
     "First and last name fields are required for running Name Match. Date-of-birth and age fields are also required, though Name Match can tolerate a small amount of missingness in those fields. Using other fields about a person's identity (e.g. race, gender, address, middle name/initial) is optional, but can be helpful to the algorithim when distinguishing people. Thus, it is a good idea to include them when they are available for the majority of records. \n",
@@ -537,6 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "57539837",
    "metadata": {},
    "outputs": [
     {
@@ -575,6 +600,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "76eb0a65",
    "metadata": {},
    "source": [
     "The fields that should be used to inform the matching algorithm in this task are: \n",
@@ -588,6 +614,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7bd95c26",
    "metadata": {},
    "source": [
     "Notice that we don't include information about the candidate's home state, even though that information is related to the candidate's identity -- this is because it is only present in one of our two datasets and would therefore not be helpful when linking.\n",
@@ -597,6 +624,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "92310ca0",
    "metadata": {},
    "source": [
     "\\* It's possible to include fields that are missing from one or more of the datasets being linked, but it is ill-advised in most circumstances."
@@ -604,6 +632,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7010b8e0",
    "metadata": {},
    "source": [
     "### Preprocessing"
@@ -611,6 +640,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5d424c9e",
    "metadata": {},
    "source": [
     "#### Basic data cleaning"
@@ -618,6 +648,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8064eca3",
    "metadata": {},
    "source": [
     "There might be a few basic data cleaning steps that need to be taken before running Name Match, such as separating fields into smaller components or converting timestamps to dates. All we need to do for this matching task is to separate the full name field into distinct first, middle, and last name fields."
@@ -626,6 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "f35b0159",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,6 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "50831140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,6 +711,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "cbe63e55",
    "metadata": {},
    "outputs": [
     {
@@ -941,6 +975,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c8cd0625",
    "metadata": {},
    "source": [
     "#### Standardizing the two data files"
@@ -948,6 +983,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ae9efe12",
    "metadata": {},
    "source": [
     "It's important that the files that are being linked together represent certain information in the same way. \n",
@@ -960,6 +996,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "6d9c1938",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,6 +1005,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "529fc978",
    "metadata": {},
    "source": [
     "The only other type of standardization needed for this matching task relates to the date fields -- specifically `dob`. One dataset encodes dates in the yyyy-mm-dd format, while the other encodes dates as dd/mm/yyyy. We'll fix this by encoding all dates in the yyyy-mm-dd format."
@@ -976,6 +1014,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "008faad1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -985,6 +1024,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "04b30a93",
    "metadata": {},
    "source": [
     "Note that standardizing column names (e.g. gender vs sex) is not necessary during pre-processing. There will be a way to refer to each variable by its original name when configuring the match -- see below."
@@ -992,6 +1032,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "23110354",
    "metadata": {},
    "source": [
     "#### Creating a single-reference age field"
@@ -999,6 +1040,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e15ebd00",
    "metadata": {},
    "source": [
     "Age can be a useful field during record matching, but only if it is calculated as of a single reference date, such as \"age as of January 1st, 2025\" below. This is necessary because it is likely that the records associated wth a given person were not all generated on the same day. For example, if a person is 18 in a record from 2010 and 26 in a record from 2016, we don't want the algorithm to see 18 and 26 and assume it's not the same person. \n",
@@ -1009,6 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "9aa353b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1018,6 +1061,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7958ca8",
    "metadata": {},
    "source": [
     "#### Locating or creating a record id"
@@ -1025,6 +1069,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e558caf0",
    "metadata": {},
    "source": [
     "Name Match must have a way of uniquely identifying each record in a given dataset. Therefore, each input dataset must have a column with a different value for every record. The `past_candidates` dataset already meets this requirement because of the `candidacy_id` field."
@@ -1033,6 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "e9e208ce",
    "metadata": {},
    "outputs": [
     {
@@ -1052,6 +1098,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b74c39e1",
    "metadata": {},
    "source": [
     "However, the `potential_candidates` dataset does not come with a unique record id -- so one must be created during pre-processing."
@@ -1060,6 +1107,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "e2a06521",
    "metadata": {},
    "outputs": [
     {
@@ -1085,6 +1133,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "09b35275",
    "metadata": {},
    "source": [
     " "
@@ -1092,6 +1141,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90c34f1e",
    "metadata": {},
    "source": [
     "#### Outputting the prepared datasets"
@@ -1099,6 +1149,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dcfa706f",
    "metadata": {},
    "source": [
     "After all of these preparation steps, our two datasets are ready for Name match! We'll write them out as CSVs."
@@ -1107,6 +1158,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "d297d9c0",
    "metadata": {},
    "outputs": [
     {
@@ -1389,6 +1441,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "0e2340cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1398,6 +1451,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59b2f3c0",
    "metadata": {},
    "source": [
     "# Running Name Match"
@@ -1405,6 +1459,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7c600b50",
    "metadata": {},
    "source": [
     "### Create the config"
@@ -1412,6 +1467,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bbc5a29b",
    "metadata": {},
    "source": [
     "There are certain decisions the user makes about what files to link, which variables to use, and what settings the algorithm should take -- the config is where you record these decisions! \n",
@@ -1421,6 +1477,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "086a81f3",
    "metadata": {},
    "source": [
     "There are three main \"sections\" of the config: the data files, the variables, and general parameters/settings. \n",
@@ -1435,6 +1492,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "daa12987",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1537,6 +1595,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "57909e81",
    "metadata": {},
    "source": [
     "### Link the data"
@@ -1544,6 +1603,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5c2ef7a9",
    "metadata": {},
    "source": [
     "To run Name Match,\n",
@@ -1556,6 +1616,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
+   "id": "0880afe6",
    "metadata": {},
    "outputs": [
     {
@@ -1576,6 +1637,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
+   "id": "ce12935b",
    "metadata": {},
    "outputs": [
     {
@@ -1686,6 +1748,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6f2e0d08",
    "metadata": {},
    "source": [
     "\\* See the runtime guidelines in the Documentation for a more specific estimate"
@@ -1693,6 +1756,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "47589bf6",
    "metadata": {},
    "source": [
     "##### Look at the final output"
@@ -1700,6 +1764,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "209e2574",
    "metadata": {},
    "source": [
     "The output datasets look exactly like the input datasets, except they now have an additional column called `cluster_id`. This is the unique person identifier that can be used to link records within and across datasets."
@@ -1708,6 +1773,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
+   "id": "5a0d5f32",
    "metadata": {},
    "outputs": [
     {
@@ -2004,6 +2070,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2d08cb4b",
    "metadata": {},
    "source": [
     "# So how many of the potential candidate have run for office before?"
@@ -2011,6 +2078,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "359a7af1",
    "metadata": {},
    "source": [
     "We can answer this question by seeing what share of `cluster_ids` from the potential candidate's dataset appear in the past candidates dataset."
@@ -2019,6 +2087,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
+   "id": "1c2b3434",
    "metadata": {},
    "outputs": [
     {
@@ -2036,6 +2105,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c63e9d13",
    "metadata": {},
    "source": [
     "# Understanding results"
@@ -2043,6 +2113,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5c9af29b",
    "metadata": {},
    "source": [
     "It is often challenging to get exact estimates of the error in your match, since the reason you needed a probabilistic record linkage solution in the first place is because you don't know exactly which records should be linked and which records shouldn't. However, there are several steps you can take to ensure there are no major problems with your matching process or results. "
@@ -2050,6 +2121,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6859b474",
    "metadata": {},
    "source": [
     "#### Look at the metrics automatically output by Name Match"
@@ -2057,6 +2129,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "82525317",
    "metadata": {},
    "source": [
     "Name Match generates several performance metrics automatically during processing. While the exact value of these measures will vary task to task, it's a good idea to understand what the metrics mean so you can gauge whether the values you're seeing make sense for your matching task. And since these metrics are output as they are calculated, they can often serve as an early warning system of any big issues with the match config or pre-processing."
@@ -2064,6 +2137,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f0bf61da",
    "metadata": {},
    "source": [
     "##### Pair Completeness"
@@ -2071,6 +2145,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ebd95675",
    "metadata": {},
    "source": [
     "One metric, called Pair Completeness, essentially measures the \"recall\" of Name Match's blocking step. Specifically, it measures how many of the name/dob pairs that are *known* to belong to the same person make it past the first big match-filtering step of the algorithm. Ideally, this measure will be ~90%+. \n",
@@ -2082,6 +2157,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f601523c",
    "metadata": {},
    "source": [
     "##### Out-of-sample precision, recall, AUC"
@@ -2089,6 +2165,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "52ee68be",
    "metadata": {},
    "source": [
     "One of the three main steps in the Name Match algorithm is a standard supervised prediction problem. A match-or-no-match model is learned using 90% (by default) of the labeled pairs. The model is then evaluated on the held-out labeled pairs, using standard binary model evaluation metrics like precision, recall, and AUC. Typical values of successful matches are ~95%+. You can find these metrics in the log under the `----- EVALUATING BASIC MATCH MODEL -----` heading. \n",
@@ -2098,6 +2175,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1ef647be",
    "metadata": {},
    "source": [
     "#### Calculate matching statistics"
@@ -2105,6 +2183,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b867fba",
    "metadata": {},
    "source": [
     "How many links were made? What share of people in dataset A appear in dataset B? How many records does each person have across all datasets -- min, max, average? These types of matching statistics can be very helpful for understanding the quality of your match.\n",
@@ -2114,6 +2193,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b8439f4",
    "metadata": {},
    "source": [
     "As another sanity check, let's see what the maximum number of records a single person has is. To do this, we'll load the \"all names\" file -- this is simply the complete list of records that were matched by the algorithm."
@@ -2122,6 +2202,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
+   "id": "7105af99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2133,6 +2214,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
+   "id": "6b2377e4",
    "metadata": {},
    "outputs": [
     {
@@ -2152,6 +2234,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9fc4bca5",
    "metadata": {},
    "source": [
     "The most times that a person has run for office is 5. This means that a person has either run in five difference races in the last 3 election years, or they've run in 4 difference races and are considering running again in the upcoming election. That seems reasonable, given that it's possible for a candidate to run for multiple seats (e.g. state and federal) in the same year. "
@@ -2159,6 +2242,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8d2a7a58",
    "metadata": {},
    "source": [
     "#### Randomly flip through clusters, especially the bigger clusters"
@@ -2166,6 +2250,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fb148ada",
    "metadata": {},
    "source": [
     "It's always a good idea to spot check some of the clusters -- groups of records assigned to the same person -- to get a micro-level view of some example links. I like to look at a random set of clusters (where at least one link was made) and then look specifically at the larger clusters."
@@ -2173,6 +2258,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c2e14615",
    "metadata": {},
    "source": [
     "##### Random clusters"
@@ -2181,6 +2267,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
+   "id": "07849f41",
    "metadata": {},
    "outputs": [
     {
@@ -2327,6 +2414,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b3cb2d7",
    "metadata": {},
    "source": [
     "##### Look at the biggest cluster(s)"
@@ -2335,6 +2423,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
+   "id": "93aae631",
    "metadata": {},
    "outputs": [
     {
@@ -2375,6 +2464,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
+   "id": "18e78300",
    "metadata": {},
    "outputs": [
     {
@@ -2526,6 +2616,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f3ecef5b",
    "metadata": {},
    "source": [
     "This 5-record cluster looks good. The algorithm linked a potential candidate to 4 records from past candidacies. One of the records has a slightly different representation of last name -- but the matching other fields indicate that including this record in the cluster was the right decision."
@@ -2534,6 +2625,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
+   "id": "769eb684",
    "metadata": {},
    "outputs": [
     {
@@ -2685,6 +2777,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0fe9c4d7",
    "metadata": {},
    "source": [
     "Despite having a record with a one-day-away DOB and having two different race values, the five records in this cluster appear to all belong to the same person."
@@ -2693,6 +2786,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
+   "id": "6dc3230e",
    "metadata": {},
    "outputs": [
     {
@@ -2844,6 +2938,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4b9a535",
    "metadata": {},
    "source": [
     "This cluster appears to have one False Positive record. Ideally, record `potential_candidates__620` would have been placed in a different cluster. However, some level of error is expected when using a probabilistic matching tool and the fact that the first name matches, most of the last name matches, and the the DOB matches makes the linking of this record to the others understandable (and forgiveable!). One extra indication that this record does not belong in the cluster is the fact that the cluster contains two records from the potential-candidates dataset. We would not expect a cluster to contain two of these records, since that dataset only contains one record per person. See the end of this tutorial for a more advanced technique for prohibiting this type of unexpected behavior. "
@@ -2851,6 +2946,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9c3db52c",
    "metadata": {},
    "source": [
     "#### Verify your expectations"
@@ -2858,6 +2954,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "78e87fcf",
    "metadata": {},
    "source": [
     "You might have a few expectations about the results, either based on what you know about Name Match or based on the parameters values you set in the config. Checking these expectations can be a nice quick way to gain confidence in your results. If these things don't look as expected, there's likely a problem with your preprocessing or config file."
@@ -2865,6 +2962,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9980cb01",
    "metadata": {},
    "source": [
     "For example, records that exact match on every field (or even just the most important fields like name and dob) should nearly always get clustered together. This is true for our match!"
@@ -2873,6 +2971,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
+   "id": "9cbb7136",
    "metadata": {},
    "outputs": [
     {
@@ -2890,6 +2989,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4948f66",
    "metadata": {},
    "source": [
     "All records with the same `official_candidate_id` (the field marked in the config with `compare_type: 'UniqueID'`) should be in the same cluster. True!"
@@ -2898,6 +2998,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
+   "id": "af5b7033",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2907,6 +3008,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
+   "id": "5a7530d9",
    "metadata": {},
    "outputs": [
     {
@@ -2926,6 +3028,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "96e01707",
    "metadata": {},
    "source": [
     "If you used the default value of `False` for the `allow_clusters_w_multiple_unique_ids` parameter, then each cluster should have at most one unique value of `official_candidate_id`. Again, this is true for our results!"
@@ -2934,6 +3037,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
+   "id": "a683c5ef",
    "metadata": {},
    "outputs": [
     {
@@ -2953,6 +3057,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "53d96dff",
    "metadata": {},
    "source": [
     "# Evaluating the results (for real)"
@@ -2960,6 +3065,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "86cfdf90",
    "metadata": {},
    "source": [
     "Normally you don't have the answer key, so you must rely on methods from the previous section to evaluate the quality of the match. However, since this is a toy problem and we DO have the answer key -- let's see how we did."
@@ -2968,6 +3074,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
+   "id": "05f415be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2982,6 +3089,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6ccbf4a2",
    "metadata": {},
    "source": [
     "### Recall -- how many actual matches did we recover?"
@@ -2990,6 +3098,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
+   "id": "f3ca26d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3004,6 +3113,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
+   "id": "712478fd",
    "metadata": {},
    "outputs": [
     {
@@ -3022,6 +3132,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "563c2e09",
    "metadata": {},
    "source": [
     "##### Look at the false negatives"
@@ -3030,6 +3141,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
+   "id": "daa7139a",
    "metadata": {},
    "outputs": [
     {
@@ -3320,6 +3432,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d5d85f2a",
    "metadata": {},
    "source": [
     "### Precision -- how many of the links we made were correct?"
@@ -3328,6 +3441,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
+   "id": "cc49caa8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3342,6 +3456,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
+   "id": "7e23d94c",
    "metadata": {},
    "outputs": [
     {
@@ -3360,6 +3475,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a39f3b94",
    "metadata": {},
    "source": [
     "##### Look at the false positives"
@@ -3368,6 +3484,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
+   "id": "b29e4a40",
    "metadata": {},
    "outputs": [
     {
@@ -3619,6 +3736,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c9a2ec00",
    "metadata": {},
    "source": [
     "### Accuracy of answer to primary research question"
@@ -3626,6 +3744,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "27965c44",
    "metadata": {},
    "source": [
     "#### According to the algorithm..."
@@ -3634,6 +3753,7 @@
   {
    "cell_type": "code",
    "execution_count": 41,
+   "id": "b2cad469",
    "metadata": {},
    "outputs": [
     {
@@ -3652,6 +3772,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ddb0094b",
    "metadata": {},
    "source": [
     "#### In reality, according to ground truth..."
@@ -3660,6 +3781,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
+   "id": "f63fe2c8",
    "metadata": {},
    "outputs": [
     {
@@ -3678,6 +3800,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "734f2225",
    "metadata": {},
    "source": [
     "# Creating custom constraints (optional/advanced)"
@@ -3685,6 +3808,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d6324850",
    "metadata": {},
    "source": [
     "Sometimes when reviewing the results of a Name Match run, you'll notice a specific type of error that occurs somewhat regularly. For example, maybe your dataset has a lot of father/son pairs with the same name (e.g. John Smith Jr and John Smtih Sr) and the records for these two different people are mistakenly getting linked together. You may wish to impose a rule that Name Match is not allowed to link two records with different non-missing suffixes (JR, SR, III, etc.). \n",
@@ -3701,6 +3825,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
+   "id": "bb3d9b2a",
    "metadata": {},
    "outputs": [
     {
@@ -3722,6 +3847,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "185447bb",
    "metadata": {},
    "source": [
     "There are a few clusters that contain 2 different potential candidate records. Therefore, we know for sure that these clusters have an error. \n",
@@ -3731,6 +3857,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "659b995f",
    "metadata": {},
    "source": [
     "### Constraint functions"
@@ -3738,6 +3865,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db9cdcbb",
    "metadata": {},
    "source": [
     "Name Match can takes as input two constraint functions, which by default return True: `is_valid_link` and `is_valid_cluster`.\n",
@@ -3749,6 +3877,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ed995cbc",
    "metadata": {},
    "source": [
     "### Our use case"
@@ -3756,6 +3885,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "759466de",
    "metadata": {},
    "source": [
     "As the user, you can alter these functions however you want. Let's see how we would do so to impose the following constraint.\n",
@@ -3766,6 +3896,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
+   "id": "9e3ee920",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3786,6 +3917,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
+   "id": "a64327e4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3801,6 +3933,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b765c21b",
    "metadata": {},
    "source": [
     "Notice how we're accessing a field called \"dataset\" -- this is a field that is created automatically by Name Match as the input datasets are loaded. Its values are the reference names assigned to each input data file in the config. The other fields that could be accessed in the constraint functions are the variables specifically defined in the config (e.g. dob, gender)."
@@ -3808,6 +3941,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d8357eef",
    "metadata": {},
    "source": [
     "To impose these constraints, this is what the call to Name Match would look like: "
@@ -3816,6 +3950,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b5254a77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3867,5 +4002,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/namematch/block.py
+++ b/namematch/block.py
@@ -186,7 +186,7 @@ class Block(NamematchBase):
             # if there are multiple spaces, split on the last one
             names_to_expand["split_names"] = (
                     names_to_expand[last_name_column].str
-                    .rsplit(" ", 1))
+                    .rsplit(pat=" ", n=1))
 
             # unpack the list of splits, so each is in its own row
             id_vars = names_to_expand.columns.tolist()
@@ -782,8 +782,8 @@ class Block(NamematchBase):
 
         # calculate cosine distance between true pairs (non-matching)
         blockstrings_in_true_pairs = \
-                tp_df.blockstring_1.append(
-                tp_df.blockstring_2, ignore_index=True).drop_duplicates().tolist()
+                pd.concat([tp_df.blockstring_1,
+                tp_df.blockstring_2], ignore_index=True).drop_duplicates().tolist()
         tp_shingles_matrix = self.generate_shingles_matrix(
                 blockstrings_in_true_pairs,
                 blocking_scheme['alpha'], blocking_scheme['power'],
@@ -792,9 +792,9 @@ class Block(NamematchBase):
                 tp_df_nonmatching, tp_shingles_matrix)
 
         # get the distribution of cosine distances in non-matching true pairs
-        tp_nonmatching_cos_distr = pd.value_counts(
-                pd.cut(tp_df_nonmatching.cos_dist, np.arange(0, 1.1, .1)),
-                normalize=True, sort=False)
+        tp_nonmatching_cos_distr = pd.Series(
+                pd.cut(tp_df_nonmatching.cos_dist, np.arange(0, 1.1, .1))
+                ).value_counts(normalize=True, sort=False)
         logger.trace(f'Cosine distribution of non-matching true pairs: \n{tp_nonmatching_cos_distr.to_string()}')
         self.stats_dict['tp_cosine_distribution'] = tp_nonmatching_cos_distr.tolist()
 
@@ -816,9 +816,9 @@ class Block(NamematchBase):
 
         # get the distribution of cosine distances in uncovered pairs
         # NOTE: fine that coming from non-matching df because no uncovered pairs will ever match
-        uncovered_pair_cos_distr = pd.value_counts(
-                pd.cut(up_df.cos_dist, np.arange(0, 1.1, .1)),
-                normalize=True, sort=False)
+        uncovered_pair_cos_distr = pd.Series(
+                pd.cut(up_df.cos_dist, np.arange(0, 1.1, .1))
+                ).value_counts(normalize=True, sort=False)
         logger.trace(f'Cosine distribution of uncovered pairs: \n{uncovered_pair_cos_distr.to_string()}')
         self.stats_dict['up_cosine_distribution'] = uncovered_pair_cos_distr.tolist()
 
@@ -1282,7 +1282,7 @@ def read_an(an_file, nn_cols, ed_col, absval_col):
     an['ed_string'] = an[ed_col]
     if absval_col is not None:
         an['absval_string'] = an[absval_col]
-        an.loc[an.absval_string == '', 'absval_string'] = np.NaN
+        an.loc[an.absval_string == '', 'absval_string'] = np.nan
         an['absval_string'] = an.absval_string.astype(float)
 
     return an

--- a/namematch/block.py
+++ b/namematch/block.py
@@ -586,6 +586,10 @@ class Block(NamematchBase):
         # batch_size = 2000 # NOTE can be parameterized/reduced if RAM is issue
         logger.debug(f"batch size: {batch_size}")
 
+        # Initialize tracking for NMSLIB filtering efficiency
+        total_neighbors_queried = 0
+        total_candidates_accepted = 0
+
         start_ix_batch = 0
         while start_ix_batch < len(nn_strings_to_query):
             end_ix_batch = min(start_ix_batch + batch_size, len(nn_strings_to_query))
@@ -622,6 +626,15 @@ class Block(NamematchBase):
                         nn_string_info,
                         nn_strings_this_index,
                         nn_strings_queried_this_batch)
+
+                # DEBUG: Save near_neighbors before any filtering (first batch only)
+                if start_ix_batch == 0 and index_type == 'main' and self.output_dir is not None:
+                    from pathlib import Path
+                    output_path = Path(self.output_dir) / 'details' / 'near_neighbors_raw.parquet'
+                    near_neighbors_df.to_parquet(output_path, index=False)
+
+                # Track total neighbors returned by NMSLIB before filtering
+                total_neighbors_queried += len(near_neighbors_df)
 
                 # parallelize the paring down for possible candidate pairs to actual candidate pairs
                 end_points = get_endpoints(len(near_neighbors_df), self.params.num_workers)
@@ -669,6 +682,9 @@ class Block(NamematchBase):
             cand_pair_df = cand_pair_df.drop_duplicates(subset=['blockstring_1', 'blockstring_2'])
             # because same name might be in both indices
 
+            # Track total candidates accepted after filtering (deduplicated within batch)
+            total_candidates_accepted += len(cand_pair_df)
+
             # update total number candidate pairs generated so far; write to file
             write_some_cps(cand_pair_df, self.candidate_pairs_file)
             del cand_pair_df
@@ -682,6 +698,29 @@ class Block(NamematchBase):
             self.candidate_pairs_file,
             index=False,
         )
+
+        # Log NMSLIB filtering efficiency statistics
+        final_candidates_after_global_dedup = len(cand_pair_df)
+        if total_neighbors_queried > 0:
+            acceptance_rate = (final_candidates_after_global_dedup / total_neighbors_queried) * 100
+            avg_neighbors_per_query = total_neighbors_queried / len(nn_strings_to_query) if len(nn_strings_to_query) > 0 else 0
+            avg_candidates_per_query = final_candidates_after_global_dedup / len(nn_strings_to_query) if len(nn_strings_to_query) > 0 else 0
+
+            logger.info(f'NMSLIB filtering efficiency:')
+            logger.info(f'  Total neighbors from NMSLIB (k={self.params.nmslib["k"]} per query): {total_neighbors_queried:,}')
+            logger.info(f'  Candidates before global dedup: {total_candidates_accepted:,}')
+            logger.info(f'  Final candidates after filtering & dedup: {final_candidates_after_global_dedup:,}')
+            logger.info(f'  Acceptance rate: {acceptance_rate:.3f}% ({final_candidates_after_global_dedup:,} / {total_neighbors_queried:,})')
+            logger.info(f'  Avg neighbors per query: {avg_neighbors_per_query:.1f}')
+            logger.info(f'  Avg final candidates per query: {avg_candidates_per_query:.1f}')
+
+            # Save to stats_dict for reporting
+            self.stats_dict['nmslib_neighbors_queried'] = total_neighbors_queried
+            self.stats_dict['nmslib_candidates_before_dedup'] = total_candidates_accepted
+            self.stats_dict['nmslib_candidates_after_dedup'] = final_candidates_after_global_dedup
+            self.stats_dict['nmslib_acceptance_rate'] = acceptance_rate
+            self.stats_dict['nmslib_avg_neighbors_per_query'] = avg_neighbors_per_query
+            self.stats_dict['nmslib_avg_candidates_per_query'] = avg_candidates_per_query
 
         return cand_pair_df
 
@@ -938,9 +977,18 @@ class Block(NamematchBase):
                 df[['commonness_penalty_1', 'commonness_penalty_2']].mean(axis=1)
         df = df.drop(columns=['commonness_penalty_1', 'commonness_penalty_2'])
 
+        # Preserve nn_string_ix if it exists (for balanced sampling)
+        has_nn_string_ix = 'nn_string_ix' in df.columns
+        if has_nn_string_ix:
+            nn_string_ix_col = df['nn_string_ix'].copy()
+
         # expand to full-name/dob/age(?) level
         df = pd.merge(df, nn_string_expanded_df, left_on='nn_string_1', right_index=True)
         df = pd.merge(df, nn_string_expanded_df, left_on='nn_string_2', right_index=True, suffixes=['_1', '_2'])
+
+        # Restore nn_string_ix after merges
+        if has_nn_string_ix:
+            df['nn_string_ix'] = nn_string_ix_col
         df = df.reset_index(drop=True)
         if 'nn_string_full' in nn_string_expanded_df:
             df['nn_string_1'] = df.nn_string_full_1 # swap nn_string for nn_string_full
@@ -988,7 +1036,12 @@ class Block(NamematchBase):
         df.loc[df.nns1_is_min == False, 'blockstring_1'] = df.nn_string_2.astype(str) + '::' + df.ed_string_2.astype(str)
         df.loc[df.nns1_is_min == False, 'blockstring_2'] = df.nn_string_1.astype(str) + '::' + df.ed_string_1.astype(str)
 
-        cand_pairs = df[['blockstring_1', 'blockstring_2', 'cos_dist', 'edit_dist']].copy()
+        # Keep nn_string_ix if it exists (needed for balanced sampling)
+        cols_to_keep = ['blockstring_1', 'blockstring_2', 'cos_dist', 'edit_dist']
+        if 'nn_string_ix' in df.columns:
+            cols_to_keep.append('nn_string_ix')
+
+        cand_pairs = df[cols_to_keep].copy()
 
         # once we've applied all the filters, the rows that are left will make it through blocking
         cand_pairs['covered_pair'] = 1
@@ -1074,6 +1127,9 @@ class Block(NamematchBase):
 
         near_neighbors_df = near_neighbors_df.copy()
 
+        # Keep track of original neighbors (before any filtering)
+        original_neighbors_df = near_neighbors_df.copy()
+
         # narrow down to reasaonable cosine distance
         near_neighbors_df = near_neighbors_df[near_neighbors_df.cos_dist <= thresholds['low_cosine_bar']]
 
@@ -1082,6 +1138,50 @@ class Block(NamematchBase):
 
         # filter out low edit or cosine distances
         cand_pairs_df = self.apply_blocking_filter(near_neighbors_df, thresholds, nn_string_expanded_df)
+
+        # Balanced sampling: For each query, if N pairs passed blocking, sample N from those that failed
+        # This creates a balanced dataset of positive and negative blocking examples
+        if thresholds.get('sample_negative_pairs', False) and len(cand_pairs_df) > 0:
+            # Get pairs that passed blocking (covered_pair = 1)
+            passed_pairs = cand_pairs_df.copy()
+            passed_pairs['covered_pair'] = 1
+
+            # Identify pairs that failed blocking by anti-joining
+            # Create a set of (nn_string_1, nn_string_2) tuples that passed
+            # Use nn_string for matching since original_neighbors_df has nn_string, not blockstring
+            passed_set = set(zip(near_neighbors_df['nn_string_1'], near_neighbors_df['nn_string_2']))
+
+            # Filter original neighbors to only those that didn't pass
+            failed_mask = ~original_neighbors_df.apply(
+                lambda row: (row['nn_string_1'], row['nn_string_2']) in passed_set, axis=1)
+            failed_pairs_df = original_neighbors_df[failed_mask].copy()
+
+            # Group by query (nn_string_ix) and sample
+            sampled_failed_pairs = []
+            for nn_string_ix, passed_group in passed_pairs.groupby('nn_string_ix'):
+                n_passed = len(passed_group)
+
+                # Get failed pairs for this query
+                failed_for_query = failed_pairs_df[failed_pairs_df['nn_string_ix'] == nn_string_ix]
+
+                if len(failed_for_query) > 0:
+                    # Sample min(n_passed, n_failed) pairs
+                    n_to_sample = min(n_passed, len(failed_for_query))
+                    sampled = failed_for_query.sample(n=n_to_sample, random_state=42)
+
+                    # Need to get blockstring columns for sampled pairs
+                    # Use nn_string_1 and nn_string_2 as blockstrings (they are the same)
+                    sampled_with_blockstrings = sampled[['nn_string_1', 'nn_string_2', 'cos_dist', 'nn_string_ix']].copy()
+                    sampled_with_blockstrings.columns = ['blockstring_1', 'blockstring_2', 'cos_dist', 'nn_string_ix']
+                    sampled_with_blockstrings['edit_dist'] = -1  # Mark as not computed
+                    sampled_with_blockstrings['covered_pair'] = 0  # Mark as not covered
+
+                    sampled_failed_pairs.append(sampled_with_blockstrings)
+
+            # Combine passed and sampled failed pairs
+            if sampled_failed_pairs:
+                sampled_failed_df = pd.concat(sampled_failed_pairs, ignore_index=True)
+                cand_pairs_df = pd.concat([passed_pairs, sampled_failed_df], ignore_index=True)
 
         if output is None:
             return cand_pairs_df
@@ -1266,6 +1366,10 @@ def read_an(an_file, nn_cols, ed_col, absval_col):
     if absval_col is not None:
         cols_to_read = nn_cols + [ed_col, absval_col, \
                 'blockstring', 'file_type', 'drop_from_nm', 'record_id']
+
+    # Remove duplicate column names while preserving order
+    # (e.g., if ed_col is same as one of nn_cols)
+    cols_to_read = list(dict.fromkeys(cols_to_read))
 
     table = pq.read_table(an_file)
     an =  table.to_pandas()

--- a/namematch/cluster.py
+++ b/namematch/cluster.py
@@ -722,6 +722,20 @@ class Cluster(NamematchBase):
         logger.info(f"Number of singleton clusters: {n_singleton_clusters}")
         self.stats_dict['n_singleton_clusters'] = n_singleton_clusters
 
+        # Save rejection reasons if available from constraints module
+        try:
+            constraints_module = cluster_logic.is_valid_cluster.__module__
+            if constraints_module != 'namematch.default_constraints':
+                import importlib
+                constraints = importlib.import_module(constraints_module)
+                if hasattr(constraints, 'rejection_reasons'):
+                    rejection_reasons_dict = dict(constraints.rejection_reasons)
+                    if rejection_reasons_dict:
+                        self.stats_dict['cluster_rejection_reasons'] = rejection_reasons_dict
+                        logger.info(f"Saved {len(rejection_reasons_dict)} rejection reason categories to stats")
+        except Exception as e:
+            logger.debug(f"Could not save rejection reasons: {e}")
+
         cluster_assignments = {k: str(v) for k, v in cluster_assignments.items()}
         return cluster_assignments
 

--- a/namematch/cluster.py
+++ b/namematch/cluster.py
@@ -465,7 +465,7 @@ class Cluster(NamematchBase):
                     potential_edges_df = potential_edges_df.reset_index(drop=True)
 
             # get clustering_phat
-            potential_edges_df['phat'] = -1
+            potential_edges_df['phat'] = -1.0
             for model_name in potential_edges_df.model_to_use.unique():
                 potential_edges_df.loc[potential_edges_df.model_to_use == model_name, 'phat'] = \
                         potential_edges_df['%s_match_phat' % model_name]

--- a/namematch/comparison_functions.py
+++ b/namematch/comparison_functions.py
@@ -334,7 +334,7 @@ def compare_geographies(df, varname):
 
     df[['x1', 'y1']] = df[col1].str.split(',', n=1, expand=True)
     df[['x2', 'y2']] = df[col2].str.split(',', n=1, expand=True)
-    df[['x1', 'y1', 'x2', 'y2']] = df[['x1', 'y1', 'x2', 'y2']].replace('', np.NaN)
+    df[['x1', 'y1', 'x2', 'y2']] = df[['x1', 'y1', 'x2', 'y2']].replace('', np.nan)
     df['x1_minus_x2_squared'] = np.square(df.x1.astype(float) - df.x2.astype(float))
     df['y1_minus_y2_squared'] = np.square(df.y1.astype(float) - df.y2.astype(float))
 

--- a/namematch/data_structures/parameters.py
+++ b/namematch/data_structures/parameters.py
@@ -248,8 +248,8 @@ class Parameters():
         if len(self.blocking_scheme['cosine_distance']['variables']) > 2:
             logger.warning(f"Only the first two variables in blocking_scheme"
                            f"['cosine_distance'] will be used.")
-            self.blocking_scheme['cosine_distance']['variable'] = \
-                    self.blocking_scheme['cosine_distance']['variable'][0:2]
+            self.blocking_scheme['cosine_distance']['variables'] = \
+                    self.blocking_scheme['cosine_distance']['variables'][0:2]
 
         if type(self.blocking_scheme['edit_distance']['variable']) == list:
             logger.warning(f"Only one variable allowed in blocking_scheme"

--- a/namematch/default_constraints.py
+++ b/namematch/default_constraints.py
@@ -34,6 +34,18 @@ def is_valid_cluster(cluster, phat):
 
     Returns:
         bool: True for default version
+
+    Note:
+        If you replace this function in a custom constraints file and want to see
+        a breakdown of *which* of your rules rejected merges (rather than just the
+        total ``n_invalid_clusters``), declare a module-level ``rejection_reasons``
+        counter (a ``Counter`` or ``defaultdict(int)``) and increment it before each
+        ``return False``. Name Match will pick it up after clustering and render
+        a sorted table in the matching report. The hook is opt-in — omitting the
+        counter leaves behavior unchanged. See the
+        "Tracking rejection reasons" subsection in
+        docs/source/match_setup.rst and examples/clue_constraints.py for a
+        worked example.
     '''
 
     return True

--- a/namematch/fit_model.py
+++ b/namematch/fit_model.py
@@ -408,15 +408,20 @@ class FitModel(NamematchBase):
             float: share of data rows that are labeled
         '''
 
-        temp_dr = load_parquet_list(
-            self.dr_file_list,
-            cols=['dr_id', 'covered_pair', 'labeled_data'])
-        n_data_rows = len(temp_dr)
+        # Count rows without loading all into memory
+        n_data_rows = 0
+        n_covered_data_rows = 0
+        logger.info("Counting data rows (chunked to avoid OOM)...")
+        for dr_file in self.dr_file_list:
+            parquet_file = pq.ParquetFile(dr_file)
+            for batch in parquet_file.iter_batches(batch_size=10000000, columns=['dr_id', 'covered_pair', 'labeled_data']):
+                batch_df = batch.to_pandas()
+                n_data_rows += len(batch_df)
+                n_covered_data_rows += (batch_df['covered_pair'] == 1).sum()
+                del batch_df
         logger.info(f"Number of data rows: {n_data_rows}")
         self.stats_dict['n_data_rows'] = n_data_rows
-        n_covered_data_rows = len(temp_dr[temp_dr.covered_pair == 1])
         self.stats_dict['n_covered_data_rows'] = n_covered_data_rows
-        del temp_dr
 
         if model_type == 'selection':
             sample = params.max_selection_train_eval_n / n_data_rows
@@ -432,10 +437,28 @@ class FitModel(NamematchBase):
             logger.error("Invalid model_type supplied: must be either 'selection' or 'match.'")
             raise
 
-        train_eval_df = load_parquet_list(
-                self.dr_file_list,
-                conditions_dict=conditions_dict,
-                sample=sample)
+        # Load train/eval data in chunks to avoid OOM
+        logger.info(f"Loading train/eval data (chunked, sample={sample:.4f})...")
+        all_chunks = []
+        for dr_file in self.dr_file_list:
+            parquet_file = pq.ParquetFile(dr_file)
+            for batch in parquet_file.iter_batches(batch_size=10000000):
+                batch_df = batch.to_pandas()
+
+                # Apply conditions
+                for col, acceptable_value in conditions_dict.items():
+                    batch_df = batch_df[batch_df[col] == acceptable_value]
+
+                # Apply sampling
+                if sample < 1:
+                    batch_df = batch_df.sample(frac=sample)
+
+                if len(batch_df) > 0:
+                    all_chunks.append(batch_df)
+                del batch_df
+
+        train_eval_df = pd.concat(all_chunks, ignore_index=True) if all_chunks else pd.DataFrame()
+        logger.info(f"Loaded {len(train_eval_df):,} train/eval rows")
 
         # create match_train_eligible flag (1 if labeled and meet data-row and all-names critiera, 0 otherwise)
         dr_train_eligible_conditions_dict = params.match_train_criteria.get('data_rows', {})
@@ -446,6 +469,19 @@ class FitModel(NamematchBase):
             prob_match_train = (train_eval_df.match_train_eligible.sum() / sample) / self.stats_dict['n_covered_data_rows']
             self.stats_dict['prob_match_train'] = float(prob_match_train)
             logger.info(f"P(s): {prob_match_train}")
+
+            # Validate base rate
+            if prob_match_train == 0.0:
+                raise ValueError(
+                    "Base rate P(s) = 0.0: No positive training examples found! "
+                    "Check that ground truth UIDs are present in the data."
+                )
+            if prob_match_train == 1.0:
+                raise ValueError(
+                    "Base rate P(s) = 1.0: No negative training examples found! "
+                    "All candidate pairs are matches. This usually means blocking is too strict "
+                    "or you need to enable hard negative mining to add difficult non-matches."
+                )
         else:
             prob_match_train = self.stats_dict.get('prob_match_train', None)
 
@@ -478,6 +514,10 @@ class FitModel(NamematchBase):
                 eval_df = train_eval_df[
                         (train_eval_df.train == 0) &
                         (train_eval_df.match_train_eligible == 1)].copy()
+
+            # Log actual training set size after pct_train sampling
+            logger.info(f'Training rows for {model_type} model (pct_train={pct_train:.2f}): {len(train_df):,}')
+            logger.info(f'Evaluation rows for {model_type} model: {len(eval_df):,}')
 
         return train_df, eval_df, prob_match_train
 

--- a/namematch/fit_model.py
+++ b/namematch/fit_model.py
@@ -357,6 +357,26 @@ class FitModel(NamematchBase):
             fscore_beta=1.0,
             **kw
             ):
+        # Load demographic data for subgroup analysis
+        demographic_variables = None
+        all_names_df = None
+        try:
+            # Load nm_info to get categorical variables from ProcessInputData
+            import yaml
+            nm_info_path = os.path.join(os.path.dirname(self.all_names_file), 'nm_info.yaml')
+            if os.path.exists(nm_info_path):
+                with open(nm_info_path, 'r') as f:
+                    nm_info = yaml.safe_load(f)
+                demographic_variables = nm_info.get('stats', {}).get('ProcessInputData', {}).get('categorical_variables', [])
+
+            if demographic_variables and len(demographic_variables) > 0:
+                # Load all_names file
+                all_names_table = pq.read_table(self.all_names_file)
+                all_names_df = all_names_table.to_pandas()
+                logger.info(f"Loaded demographic data for {len(demographic_variables)} categorical variables: {demographic_variables}")
+        except Exception as e:
+            logger.warning(f"Could not load demographic data for subgroup analysis: {e}")
+
         return evaluate_models(
                     phats_df,
                     outcome,
@@ -367,6 +387,8 @@ class FitModel(NamematchBase):
                     optimize_threshold,
                     fscore_beta,
                     self.stats_dict,
+                    demographic_variables,
+                    all_names_df,
                     )
 
     def get_train_eval_data(self, an_train_eligible_dict, model_info, params, model_type, any_train=True):

--- a/namematch/matching_report.ipynb
+++ b/namematch/matching_report.ipynb
@@ -6,12 +6,7 @@
    "id": "020c49b3",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import yaml\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "from IPython.core.display import display, Markdown"
-   ]
+   "source": "import yaml\nimport pandas as pd\nimport numpy as np\nimport matplotlib.pyplot as plt\nfrom IPython.display import display, Markdown, HTML"
   },
   {
    "cell_type": "code",
@@ -48,42 +43,14 @@
    "id": "1a859c93",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "if not metadata['params']['incremental']:\n",
-    "    prediction_stats = stats['FitModel']['model_stats__match']['basic']['all pairs']\n",
-    "    key_stats = {\n",
-    "        'Blocking: pair completeness': stats['Block']['pc_eq_cosed'],\n",
-    "        'Blocking: pair completeness (excluding exact matches)': stats['Block']['pc_neq_cosed'],\n",
-    "        'Prediction: baserate, or P(match) in ground truth data': prediction_stats['baserate'],\n",
-    "        'Prediction: precision': prediction_stats['precision'],\n",
-    "        'Prediction: recall': prediction_stats['recall'],\n",
-    "        'Prediction: AUC': prediction_stats['auc'],\n",
-    "        'Prediction: false positive rate': prediction_stats['fp_rate'],\n",
-    "        'Prediction: false negative rate': prediction_stats['fn_rate']\n",
-    "    }\n",
-    "\n",
-    "n_valid = stats['ProcessInputData']['n_valid_an']\n",
-    "key_ns = {\n",
-    "    'Number of records': stats['ProcessInputData']['n_an'],\n",
-    "    'Number of records with required values': n_valid,\n",
-    "    'Number of possible record pairs': (n_valid * (n_valid-1)) / 2,\n",
-    "    'Number of candidate record pairs (record pairs considered post blocking)': stats['Block'].get('n_cand_pairs', np.NaN),\n",
-    "    'Number of potential links (candidate record pairs predicted to match)': stats['Cluster']['n_potential_edges'],\n",
-    "    'Number of potential links deemed invalid by pair-level constraints': stats['Cluster']['n_invalid_links'],\n",
-    "    'Number of potential links deemed invalid by cluster-level constraints': stats['Cluster']['n_invalid_clusters'],\n",
-    "    'Number of final clusters': stats['Cluster']['n_clusters'],\n",
-    "    'Number of final clusters with no links (i.e. one-record clusters)': stats['Cluster']['n_singleton_clusters']\n",
-    "}\n",
-    "if metadata['params']['incremental']:\n",
-    "    _ = key_ns.pop('Number of candidate record pairs (record pairs considered post blocking)')"
-   ]
+   "source": "if not metadata['params']['incremental']:\n    match_model_stats = stats['FitModel']['model_stats__match']['basic']\n    \n    prediction_stats = match_model_stats['all pairs']\n    exactmatch_stats = match_model_stats.get('exactmatch pairs', {})\n    non_exactmatch_stats = match_model_stats.get('non exactmatch pairs', {})\n    \n    key_stats = {\n        'Blocking: pair completeness': stats['Block']['pc_eq_cosed'],\n        'Blocking: pair completeness (excluding exact matches)': stats['Block']['pc_neq_cosed'],\n        '': np.nan,  # spacer row\n        'Prediction (All Pairs): baserate, or P(match) in ground truth data': prediction_stats['baserate'],\n        'Prediction (All Pairs): precision': prediction_stats['precision'],\n        'Prediction (All Pairs): recall': prediction_stats['recall'],\n        'Prediction (All Pairs): AUC': prediction_stats['auc'],\n        'Prediction (All Pairs): false positive rate': prediction_stats['fp_rate'],\n        'Prediction (All Pairs): false negative rate': prediction_stats['fn_rate'],\n        ' ': np.nan,  # spacer row\n        'Prediction (Exact Match Pairs): precision': exactmatch_stats.get('precision', np.nan),\n        'Prediction (Exact Match Pairs): recall': exactmatch_stats.get('recall', np.nan),\n        'Prediction (Exact Match Pairs): AUC': exactmatch_stats.get('auc', np.nan),\n        'Prediction (Exact Match Pairs): false positive rate': exactmatch_stats.get('fp_rate', np.nan),\n        'Prediction (Exact Match Pairs): false negative rate': exactmatch_stats.get('fn_rate', np.nan),\n        '  ': np.nan,  # spacer row\n        'Prediction (Non-Exact Match Pairs): precision': non_exactmatch_stats.get('precision', np.nan),\n        'Prediction (Non-Exact Match Pairs): recall': non_exactmatch_stats.get('recall', np.nan),\n        'Prediction (Non-Exact Match Pairs): AUC': non_exactmatch_stats.get('auc', np.nan),\n        'Prediction (Non-Exact Match Pairs): false positive rate': non_exactmatch_stats.get('fp_rate', np.nan),\n        'Prediction (Non-Exact Match Pairs): false negative rate': non_exactmatch_stats.get('fn_rate', np.nan)\n    }\n\nn_valid = stats['ProcessInputData']['n_valid_an']\nkey_ns = {\n    'Number of records': stats['ProcessInputData']['n_an'],\n    'Number of records with required values': n_valid,\n    'Number of possible record pairs': (n_valid * (n_valid-1)) / 2,\n    'Number of candidate record pairs (record pairs considered post blocking)': stats['Block'].get('n_cand_pairs', np.nan),\n    'Number of potential links (candidate record pairs predicted to match)': stats['Cluster']['n_potential_edges'],\n    'Number of potential links deemed invalid by pair-level constraints': stats['Cluster']['n_invalid_links'],\n    'Number of potential links deemed invalid by cluster-level constraints': stats['Cluster']['n_invalid_clusters'],\n    'Number of final clusters': stats['Cluster']['n_clusters'],\n    'Number of final clusters with no links (i.e. one-record clusters)': stats['Cluster']['n_singleton_clusters']\n}\nif metadata['params']['incremental']:\n    _ = key_ns.pop('Number of candidate record pairs (record pairs considered post blocking)')"
   },
   {
    "cell_type": "markdown",
    "id": "ce54e2ce",
    "metadata": {},
    "source": [
-    "# Key performance metrics"
+    "# Key Performance Metrics"
    ]
   },
   {
@@ -91,7 +58,7 @@
    "id": "e1cd5b18",
    "metadata": {},
    "source": [
-    "Note: Prediction performance metrics (precision, recall, AUC, false positive rate, and false negative rate) are reported out of sample. That is, they are computed on *heldout* ground truth data not used in model training.  "
+    "Note: Prediction performance metrics (precision, recall, AUC, false positive rate, and false negative rate) are reported out of sample. That is, they are computed on *heldout* ground truth data not used in model training."
    ]
   },
   {
@@ -100,19 +67,14 @@
    "id": "0417a341",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "if not metadata['params']['incremental']:\n",
-    "    display(pd.DataFrame(pd.Series(key_stats).rename(\"\")).style.format('{:.1%}'))\n",
-    "else:\n",
-    "    display(Markdown(\"<font color='red'>Key performance metrics are not yet supported for incremental Name Match runs.</font>\"))"
-   ]
+   "source": "if not metadata['params']['incremental']:\n    # Custom formatter to handle None and spacer rows\n    def format_metric(x):\n        if pd.isna(x):\n            return ''  # Spacer rows show as blank\n        if x is None:\n            return 'N/A'\n        return f'{x:.1%}'\n\n    display(pd.DataFrame(pd.Series(key_stats).rename(\"\")).style.format(format_metric))\nelse:\n    display(Markdown(\"<font color='red'>Key performance metrics are not yet supported for incremental Name Match runs.</font>\"))"
   },
   {
    "cell_type": "markdown",
    "id": "360249e6",
    "metadata": {},
    "source": [
-    "# Important counts: understanding how final links are made"
+    "# Important Counts: Understanding How Final Links Are Made"
    ]
   },
   {
@@ -126,6 +88,166 @@
    "source": [
     "pd.DataFrame(pd.Series(key_ns).rename(\"\")).style.format('{:,.0f}')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lf6op4gugj",
+   "source": "# Data Quality Indicators",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "e0xiax2gaiq",
+   "source": "n_an = stats['ProcessInputData']['n_an']\nn_valid_an = stats['ProcessInputData']['n_valid_an']\nn_dropped = n_an - n_valid_an\nn_cand_pairs = stats['Block'].get('n_cand_pairs', 0)\n\nquality_metrics = {\n    'Records dropped during preprocessing': n_dropped,\n    'Proportion of records dropped': n_dropped / n_an if n_an > 0 else 0,\n    'Candidate pairs generated per valid record': n_cand_pairs / n_valid_an if n_valid_an > 0 else 0\n}\n\nquality_df = pd.DataFrame(pd.Series(quality_metrics).rename(\"\"))\nquality_df_styled = quality_df.style.format({\n    'Records dropped during preprocessing': '{:,.0f}',\n    'Proportion of records dropped': '{:.1%}',\n    'Candidate pairs generated per valid record': '{:.1f}'\n})\ndisplay(quality_df_styled)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89d7zjmxxeq",
+   "source": "# Selection Model Performance",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "u8rpzjcvn6m",
+   "source": "The **selection model** predicts whether a candidate pair came from labeled training data (S=1) or unlabeled data (S=0). This model is used to reweight the match model training to correct for differences between the training domain (labeled pairs with ground truth) and the prediction domain (unlabeled pairs).\n\n**Key Metric - P(s):** The proportion of candidate pairs that have ground truth labels available for training.\n\n**Interpreting Selection Model Performance:**\n- **Low AUC (< 0.6):** Training and prediction domains are similar → good for model transfer\n- **Medium AUC (0.6-0.8):** Some domain differences → weighting helps correct for distribution shift\n- **High AUC (> 0.8):** Significant domain shift → review feature importance to understand differences\n- **Very High AUC (> 0.95):** Strong domain separation → manual review recommended; may indicate training data has different error patterns than prediction data",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "5ur4blpafbd",
+   "source": "if metadata['params'].get('weight_using_selection_model', False) and not metadata['params']['incremental']:\n    selection_stats = stats['FitModel']['model_stats__selection']['basic']['all pairs']\n    prob_s = stats['FitModel'].get('prob_match_train', np.nan)\n    \n    selection_key_stats = {\n        'P(s): Prevalence of labeled data in candidate pairs': prob_s,\n        'Selection model: Precision (predicting labeled vs unlabeled)': selection_stats.get('precision', np.nan),\n        'Selection model: Recall': selection_stats.get('recall', np.nan),\n        'Selection model: AUC': selection_stats.get('auc', np.nan),\n        'Selection model: Base rate (S=1)': selection_stats.get('baserate', np.nan)\n    }\n    \n    # Custom formatter to handle None values\n    def format_metric(x):\n        if pd.isna(x) or x is None:\n            return 'N/A'\n        return f'{x:.1%}'\n    \n    display(pd.DataFrame(pd.Series(selection_key_stats).rename(\"\")).style.format(format_metric))\nelse:\n    display(Markdown(\"**Selection model not enabled.** Set `weight_using_selection_model: True` in config to use.\"))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q58n46t57hk",
+   "source": "# Feature Importance",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1w8churgyyl",
+   "source": "Feature importance shows which variables are most predictive for the model. Higher values indicate features that are more important for making accurate predictions.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g0kctvrixgn",
+   "source": "## Match Model: Top 20 Features",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "jeze07iijw",
+   "source": "if not metadata['params']['incremental']:\n    match_features = stats['FitModel']['feature_info__match']['basic']\n    match_fi_df = pd.DataFrame({\n        'Feature': match_features['retained'],\n        'Importance': match_features['imp']\n    }).sort_values('Importance', ascending=False).head(20).reset_index(drop=True)\n    \n    display(match_fi_df.style.format({'Importance': '{:.4f}'}).hide(axis='index'))\nelse:\n    display(Markdown(\"Feature importance not available for incremental runs.\"))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2xrwxtv71m6",
+   "source": "## Selection Model: Top 20 Features",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3jf5fym2i5o",
+   "source": "These features distinguish labeled training pairs from unlabeled pairs. High importance indicates the feature distribution differs significantly between training and prediction domains.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "v0yuyc099pd",
+   "source": "if metadata['params'].get('weight_using_selection_model', False) and not metadata['params']['incremental']:\n    selection_features = stats['FitModel']['feature_info__selection']['basic']\n    selection_fi_df = pd.DataFrame({\n        'Feature': selection_features['retained'],\n        'Importance': selection_features['imp']\n    }).sort_values('Importance', ascending=False).head(20).reset_index(drop=True)\n    \n    display(selection_fi_df.style.format({'Importance': '{:.4f}'}).hide(axis='index'))\nelse:\n    display(Markdown(\"Selection model not enabled.\"))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04y0hw9fyxe2",
+   "source": "# Match Probability Distributions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2rk35ocdomy",
+   "source": "This visualization shows how well-calibrated the match model is. Ideally:\n- **True matches (label=1)** should have high predicted probabilities (bars concentrated on the right)\n- **True non-matches (label=0)** should have low predicted probabilities (bars concentrated on the left)\n- Clear separation indicates good model discrimination",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "lhjlnlxu8g",
+   "source": "if not metadata['params']['incremental']:\n    match_stats = stats['FitModel']['model_stats__match']['basic']['all pairs']\n    \n    phat_dist_1s = match_stats.get('phat_distribution_1s', [])\n    phat_dist_0s = match_stats.get('phat_distribution_0s', [])\n    \n    if phat_dist_1s and phat_dist_0s:\n        fig, ax = plt.subplots(1, 1, figsize=(12, 6))\n        bins = [f'{i/10:.1f}-{(i+1)/10:.1f}' for i in range(10)]\n        \n        x = np.arange(len(bins))\n        width = 0.35\n        \n        ax.bar(x - width/2, phat_dist_1s, width, label='True Matches (label=1)', alpha=0.8, color='#2ecc71')\n        ax.bar(x + width/2, phat_dist_0s, width, label='True Non-Matches (label=0)', alpha=0.8, color='#e74c3c')\n        \n        ax.set_xlabel('Predicted Probability (phat)', fontsize=12)\n        ax.set_ylabel('Proportion of Pairs', fontsize=12)\n        ax.set_title('Distribution of Match Probabilities by True Label', fontsize=14, fontweight='bold')\n        ax.set_xticks(x)\n        ax.set_xticklabels(bins, rotation=45, ha='right')\n        ax.legend(fontsize=11)\n        ax.grid(axis='y', alpha=0.3)\n        \n        plt.tight_layout()\n        plt.show()\n    else:\n        display(Markdown(\"Phat distribution data not available.\"))\nelse:\n    display(Markdown(\"Phat distributions not available for incremental runs.\"))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47cizlxz9ro",
+   "source": "# Performance by Pair Type",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vtl3erd3xu",
+   "source": "This section breaks down model performance for:\n- **Exact match pairs:** Pairs with identical names and DOB (easier to classify)\n- **Non-exact match pairs:** Pairs with variation in names/DOB (harder to classify)\n\nNon-exact match performance is particularly important for assessing the model's ability to link records with typos, nicknames, or data entry errors.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "idu7zwf4vvn",
+   "source": "if not metadata['params']['incremental']:\n    match_model_stats = stats['FitModel']['model_stats__match']['basic']\n    \n    exactmatch_stats = match_model_stats.get('exactmatch pairs', {})\n    non_exactmatch_stats = match_model_stats.get('non exactmatch pairs', {})\n    \n    breakdown_stats = {\n        'Exact Match Pairs: Precision': exactmatch_stats.get('precision', np.nan),\n        'Exact Match Pairs: Recall': exactmatch_stats.get('recall', np.nan),\n        'Exact Match Pairs: AUC': exactmatch_stats.get('auc', np.nan),\n        'Non-Exact Match Pairs: Precision': non_exactmatch_stats.get('precision', np.nan),\n        'Non-Exact Match Pairs: Recall': non_exactmatch_stats.get('recall', np.nan),\n        'Non-Exact Match Pairs: AUC': non_exactmatch_stats.get('auc', np.nan),\n    }\n    \n    # Custom formatter to handle None values\n    def format_metric(x):\n        if pd.isna(x) or x is None:\n            return 'N/A'\n        return f'{x:.1%}'\n    \n    display(pd.DataFrame(pd.Series(breakdown_stats).rename(\"\")).style.format(format_metric))\nelse:\n    display(Markdown(\"Pair type breakdown not available for incremental runs.\"))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "xsa35mrfu2b",
+   "source": "# Model Thresholds",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wsf9qdxman",
+   "source": "The threshold determines which predicted probabilities are classified as matches. Pairs with predicted probability ≥ threshold are considered matches.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "v6s8gd8hpw",
+   "source": "if not metadata['params']['incremental']:\n    thresholds = stats['FitModel'].get('model_thresholds__match', {})\n    \n    threshold_df = pd.DataFrame([\n        {'Model': model_name, 'Threshold': threshold}\n        for model_name, threshold in thresholds.items()\n    ])\n    \n    if len(threshold_df) > 0:\n        display(threshold_df.style.format({'Threshold': '{:.3f}'}).hide(axis='index'))\n    else:\n        display(Markdown(\"Threshold information not available.\"))\nelse:\n    display(Markdown(\"Threshold information not available for incremental runs.\"))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "z5kww91c7cm",
+   "source": "# Performance by Demographics",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pcwmpokkhk",
+   "source": "This section analyzes model performance across different demographic groups (categorical variables like race, gender, marital status, etc.).\n\n**Why this matters:**\n- **Fairness analysis**: Detect if the model performs differently for different groups\n- **Bias detection**: Identify systematic errors that may affect specific populations\n- **Model validation**: Ensure consistent performance across all demographic segments\n\n**How to interpret:**\n- Look for large performance gaps between demographic groups\n- Small sample sizes (N < 100) may have less reliable metrics\n- Both records in a pair contribute to the demographic analysis (inclusive counting)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "5d4ndqms1r9",
+   "source": "if not metadata['params']['incremental']:\n    # Get categorical variables\n    categorical_vars = stats['ProcessInputData'].get('categorical_variables', [])\n    \n    if len(categorical_vars) == 0:\n        display(Markdown(\"**No categorical variables defined.** Add categorical variables to your config to enable demographic analysis.\"))\n    else:\n        match_model_stats = stats['FitModel']['model_stats__match']['basic']\n        \n        for demog_var in categorical_vars:\n            # Find all demographic groups for this variable\n            demog_keys = [k for k in match_model_stats.keys() if k.startswith(f'{demog_var}:')]\n            \n            if len(demog_keys) == 0:\n                display(Markdown(f\"### {demog_var.replace('_', ' ').title()}\"))\n                display(Markdown(f\"*No demographic breakdowns available (insufficient sample sizes)*\"))\n                continue\n            \n            # Extract stats for each demographic value\n            demog_stats_list = []\n            for key in demog_keys:\n                demog_value = key.split(':', 1)[1]\n                demog_stats = match_model_stats[key]\n                \n                demog_stats_list.append({\n                    'Value': demog_value,\n                    'Precision': demog_stats.get('precision', np.nan),\n                    'Recall': demog_stats.get('recall', np.nan),\n                    'AUC': demog_stats.get('auc', np.nan),\n                    'FPR': demog_stats.get('fp_rate', np.nan),\n                    'FNR': demog_stats.get('fn_rate', np.nan)\n                })\n            \n            if len(demog_stats_list) > 0:\n                demog_df = pd.DataFrame(demog_stats_list)\n                \n                # Display section header\n                display(Markdown(f\"### {demog_var.replace('_', ' ').title()}\"))\n                \n                # Format values, handling None gracefully\n                def format_pct(x):\n                    if pd.isna(x) or x is None:\n                        return 'N/A'\n                    return f'{x:.1%}'\n                \n                # Display styled table\n                styled_df = demog_df.style.format({\n                    'Precision': format_pct,\n                    'Recall': format_pct,\n                    'AUC': format_pct,\n                    'FPR': format_pct,\n                    'FNR': format_pct\n                }).hide(axis='index')\n                \n                display(styled_df)\n                display(Markdown(\"\"))  # Add spacing\nelse:\n    display(Markdown(\"Demographic breakdowns not available for incremental runs.\"))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/namematch/matching_report.ipynb
+++ b/namematch/matching_report.ipynb
@@ -91,6 +91,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cluster Rejection Reasons\n",
+    "\n",
+    "When the clustering algorithm considers merging two clusters, it checks various constraints. If any constraint is violated, the merge is rejected. This table shows which constraints caused the most rejections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rejection_reasons = stats.get('Cluster', {}).get('cluster_rejection_reasons', {})\n",
+    "if rejection_reasons:\n",
+    "    rejection_df = pd.DataFrame([\n",
+    "        {'Rejection Reason': reason.replace('_', ' ').title(), 'Count': count}\n",
+    "        for reason, count in sorted(rejection_reasons.items(), key=lambda x: x[1], reverse=True)\n",
+    "    ])\n",
+    "    rejection_df['Percentage'] = (100.0 * rejection_df['Count'] / rejection_df['Count'].sum()).round(1)\n",
+    "    display(rejection_df.style.format({'Count': '{:,}', 'Percentage': '{:.1f}%'}).hide(axis='index'))\n",
+    "else:\n",
+    "    print('No cluster rejections recorded (using default constraints or no rejections occurred)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "lf6op4gugj",
    "source": "# Data Quality Indicators",
    "metadata": {}
@@ -112,7 +139,7 @@
   {
    "cell_type": "markdown",
    "id": "u8rpzjcvn6m",
-   "source": "The **selection model** predicts whether a candidate pair came from labeled training data (S=1) or unlabeled data (S=0). This model is used to reweight the match model training to correct for differences between the training domain (labeled pairs with ground truth) and the prediction domain (unlabeled pairs).\n\n**Key Metric - P(s):** The proportion of candidate pairs that have ground truth labels available for training.\n\n**Interpreting Selection Model Performance:**\n- **Low AUC (< 0.6):** Training and prediction domains are similar → good for model transfer\n- **Medium AUC (0.6-0.8):** Some domain differences → weighting helps correct for distribution shift\n- **High AUC (> 0.8):** Significant domain shift → review feature importance to understand differences\n- **Very High AUC (> 0.95):** Strong domain separation → manual review recommended; may indicate training data has different error patterns than prediction data",
+   "source": "The **selection model** predicts whether a candidate pair came from labeled training data (S=1) or unlabeled data (S=0). This model is used to reweight the match model training to correct for differences between the training domain (labeled pairs with ground truth) and the prediction domain (unlabeled pairs).\n\n**Key Metric - P(s):** The proportion of candidate pairs that have ground truth labels available for training.\n\n**Interpreting Selection Model Performance:**\n- **Low AUC (< 0.6):** Training and prediction domains are similar \u2192 good for model transfer\n- **Medium AUC (0.6-0.8):** Some domain differences \u2192 weighting helps correct for distribution shift\n- **High AUC (> 0.8):** Significant domain shift \u2192 review feature importance to understand differences\n- **Very High AUC (> 0.95):** Strong domain separation \u2192 manual review recommended; may indicate training data has different error patterns than prediction data",
    "metadata": {}
   },
   {
@@ -218,7 +245,7 @@
   {
    "cell_type": "markdown",
    "id": "wsf9qdxman",
-   "source": "The threshold determines which predicted probabilities are classified as matches. Pairs with predicted probability ≥ threshold are considered matches.",
+   "source": "The threshold determines which predicted probabilities are classified as matches. Pairs with predicted probability \u2265 threshold are considered matches.",
    "metadata": {}
   },
   {

--- a/namematch/model_evaluation_functions.py
+++ b/namematch/model_evaluation_functions.py
@@ -216,7 +216,8 @@ def get_cv_metrics(mod):
 
 def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
         default_threshold=0.5, missingness_model_threshold_boost=0.2,
-        optimize_threshold=False, fscore_beta=1.0, demographic_variables=None, all_names_df=None):
+        optimize_threshold=False, fscore_beta=1.0, demographic_variables=None, all_names_df=None,
+        max_demographic_values=10):
     '''Calculates metrics such as precision, recall, fscore, etc. for the pairwise record
     match predictions. Also, get the threshold that maximizes f score.
 
@@ -232,6 +233,7 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
         fscore_beta (float): ratio of recall weighting to precision weighting (e.g. 0.5 weights precision double)
         demographic_variables (list): list of demographic/categorical variable names for subgroup analysis
         all_names_df (pd.DataFrame): all_names dataframe with demographic columns and record_id
+        max_demographic_values (int): maximum number of unique values for a demographic variable to report performance by category (default: 10)
 
     Returns:
         float: probability threshold that optimizes fscore
@@ -288,6 +290,12 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
                     values_1 = set(phat_df[col1].dropna().unique())
                     values_2 = set(phat_df[col2].dropna().unique())
                     all_values = values_1 | values_2
+
+                    # Skip demographic variable if it has too many unique values
+                    n_unique_values = len(all_values)
+                    if n_unique_values > max_demographic_values:
+                        logger.info(f"Skipping demographic variable '{demog_var}' ({n_unique_values} unique values > max {max_demographic_values})")
+                        continue
 
                     # Create universe for each value (only if enough samples)
                     for value in all_values:
@@ -360,25 +368,36 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
                 baserate, precision, recall, fpr, fnr, auc, accuracy, fscore = pairwise_metrics(
                     phat_univ_df, threshold, phat_col, outcome, fscore_beta, weight)
 
-            logger.info(f"Base rate ({universe}): {baserate}")
+            # Only log performance metrics for base universes, not demographic subgroups
+            # Demographic stats are still saved to stats_dict for the matching report
+            is_demographic_universe = ':' in universe
+
+            if not is_demographic_universe:
+                logger.info(f"Base rate ({universe}): {baserate}")
             model_stats['baserate'] = float(baserate) if baserate is not None else None
 
-            logger.info(f"Precision ({universe}): {precision}")
+            if not is_demographic_universe:
+                logger.info(f"Precision ({universe}): {precision}")
             model_stats['precision'] = float(precision) if precision is not None else None
 
-            logger.info(f"Recall ({universe}): {recall}")
+            if not is_demographic_universe:
+                logger.info(f"Recall ({universe}): {recall}")
             model_stats['recall'] = float(recall) if recall is not None else None
 
-            logger.info(f"False positive rate ({universe}): {fpr}")
+            if not is_demographic_universe:
+                logger.info(f"False positive rate ({universe}): {fpr}")
             model_stats['fp_rate'] = float(fpr) if fpr is not None else None
 
-            logger.info(f"False negative rate ({universe}): {fnr}")
+            if not is_demographic_universe:
+                logger.info(f"False negative rate ({universe}): {fnr}")
             model_stats['fn_rate'] = float(fnr) if fnr is not None else None
 
-            logger.info(f"AUC ({universe}): {auc}")
+            if not is_demographic_universe:
+                logger.info(f"AUC ({universe}): {auc}")
             model_stats['auc'] = float(auc) if auc is not None else None
 
-            logger.info(f"F-score ({universe}): {fscore}")
+            if not is_demographic_universe:
+                logger.info(f"F-score ({universe}): {fscore}")
             model_stats['fscore'] = float(fscore) if fscore is not None else None
 
         except:
@@ -395,7 +414,7 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
 
 def evaluate_models(phats_df, outcome, model_type, weight=False, default_threshold=0.5,
             missingness_model_threshold_boost=0.2, optimize_threshold=False, fscore_beta=1.0,
-            stats_dict=None, demographic_variables=None, all_names_df=None):
+            stats_dict=None, demographic_variables=None, all_names_df=None, max_demographic_values=10):
     '''Wrapper for evaluating different models (e.g. basic and no-dob) on different universes.
 
     Args:
@@ -409,6 +428,7 @@ def evaluate_models(phats_df, outcome, model_type, weight=False, default_thresho
         fscore_beta (float): ratio of recall weighting to precision weighting (e.g. 0.5 weights precision double)
         demographic_variables (list): list of demographic/categorical variable names for subgroup analysis
         all_names_df (pd.DataFrame): all_names dataframe with demographic columns and record_id
+        max_demographic_values (int): maximum number of unique values for a demographic variable to report performance by category (default: 10)
 
     Return:
         dict: maps model name (e.g. basic, no-dob) to thresholds (no return type)
@@ -437,7 +457,7 @@ def evaluate_models(phats_df, outcome, model_type, weight=False, default_thresho
         model_type_model_stats[model_name] = evaluate_predictions(
                 phats_to_eval_df, model_type, phat_col, outcome, weight,
                 default_threshold, missingness_model_threshold_boost, optimize_threshold, fscore_beta,
-                demographic_variables, all_names_df)
+                demographic_variables, all_names_df, max_demographic_values)
     
     stats_dict[f"model_stats__{model_type}"] = model_type_model_stats
     if model_type == 'match':

--- a/namematch/model_evaluation_functions.py
+++ b/namematch/model_evaluation_functions.py
@@ -129,7 +129,12 @@ def pairwise_metrics(labeled_preds, threshold, phat_col, outcome, fscore_beta, w
         weights = [1 for i in np.arange(len(labeled_preds))]
 
     base_rate = np.average(labels, weights=weights)
-    auc = metrics.roc_auc_score(labels, preds, sample_weight=weights)
+
+    # Check if only one class is present to avoid ROC AUC warning
+    if len(np.unique(labels)) < 2:
+        auc = None
+    else:
+        auc = metrics.roc_auc_score(labels, preds, sample_weight=weights)
 
     eval_df = pd.DataFrame(data={
         'phat':preds, 
@@ -210,8 +215,8 @@ def get_cv_metrics(mod):
 
 
 def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
-        default_threshold=0.5, missingness_model_threshold_boost=0.2, 
-        optimize_threshold=False, fscore_beta=1.0):
+        default_threshold=0.5, missingness_model_threshold_boost=0.2,
+        optimize_threshold=False, fscore_beta=1.0, demographic_variables=None, all_names_df=None):
     '''Calculates metrics such as precision, recall, fscore, etc. for the pairwise record
     match predictions. Also, get the threshold that maximizes f score.
 
@@ -225,6 +230,8 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
         missingness_model_threshold_boost (float): value to add to default threshold if missingess model
         optimize_threshold (bool): should we find the threshold that optimizes f1
         fscore_beta (float): ratio of recall weighting to precision weighting (e.g. 0.5 weights precision double)
+        demographic_variables (list): list of demographic/categorical variable names for subgroup analysis
+        all_names_df (pd.DataFrame): all_names dataframe with demographic columns and record_id
 
     Returns:
         float: probability threshold that optimizes fscore
@@ -251,6 +258,53 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
 
     logger.info(f'Number of labeled test rows evaluated: {len(phat_df)}')
 
+    # Join demographic data if provided
+    demographic_universes = []
+    if demographic_variables and all_names_df is not None and len(demographic_variables) > 0:
+        try:
+            # Select only needed columns from all_names
+            demographic_cols = ['record_id'] + demographic_variables
+            demographic_cols = [col for col in demographic_cols if col in all_names_df.columns]
+            all_names_subset = all_names_df[demographic_cols].copy()
+
+            # Join demographics for both records in the pair
+            phat_df = phat_df.merge(
+                all_names_subset.rename(columns={col: f'{col}_1' if col != 'record_id' else 'record_id' for col in all_names_subset.columns}),
+                left_on='record_id_1', right_on='record_id', how='left'
+            ).drop(columns=['record_id'], errors='ignore')
+
+            phat_df = phat_df.merge(
+                all_names_subset.rename(columns={col: f'{col}_2' if col != 'record_id' else 'record_id' for col in all_names_subset.columns}),
+                left_on='record_id_2', right_on='record_id', how='left'
+            ).drop(columns=['record_id'], errors='ignore')
+
+            # Build demographic universes dynamically from data
+            for demog_var in demographic_variables:
+                col1 = f'{demog_var}_1'
+                col2 = f'{demog_var}_2'
+
+                if col1 in phat_df.columns and col2 in phat_df.columns:
+                    # Get unique values from both columns
+                    values_1 = set(phat_df[col1].dropna().unique())
+                    values_2 = set(phat_df[col2].dropna().unique())
+                    all_values = values_1 | values_2
+
+                    # Create universe for each value (only if enough samples)
+                    for value in all_values:
+                        universe_name = f'{demog_var}:{value}'
+                        # Count how many pairs have this demographic (either record)
+                        mask = (phat_df[col1] == value) | (phat_df[col2] == value)
+                        n_pairs = mask.sum()
+
+                        if n_pairs >= 30:  # Minimum sample size threshold
+                            demographic_universes.append(universe_name)
+                        else:
+                            logger.debug(f"Skipping demographic universe '{universe_name}' (only {n_pairs} pairs, minimum 30 required)")
+
+            logger.info(f"Evaluating {len(demographic_universes)} demographic universes")
+        except Exception as e:
+            logger.warning(f"Could not join demographic data for subgroup analysis: {e}")
+
     if optimize_threshold:
         try:
             df = phat_df[[phat_col, outcome, weight_col]].copy()
@@ -263,7 +317,11 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
         threshold = default_threshold
     logger.info(f"Threshold: {threshold}")
 
-    for universe in ['all pairs', 'non exactmatch pairs', 'exactmatch pairs']:
+    # Build list of universes to evaluate
+    base_universes = ['all pairs', 'non exactmatch pairs', 'exactmatch pairs']
+    all_universes = base_universes + demographic_universes
+
+    for universe in all_universes:
 
         model_stats = {}
 
@@ -272,17 +330,23 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
             phat_univ_df = phat_df[phat_df.exactmatch == 0].copy()
         elif universe == 'exactmatch pairs':
             phat_univ_df = phat_df[phat_df.exactmatch == 1].copy()
+        elif ':' in universe:  # Demographic universe (e.g., 'race:BRANCA')
+            demog_var, demog_value = universe.split(':', 1)
+            col1 = f'{demog_var}_1'
+            col2 = f'{demog_var}_2'
+            # Include pairs where either record has this demographic value
+            phat_univ_df = phat_df[(phat_df[col1] == demog_value) | (phat_df[col2] == demog_value)].copy()
 
         # log phat distributions
         try:
 
             one_phats = phat_univ_df[phat_univ_df[outcome] == 1][phat_col]
-            one_phat_dist = pd.value_counts(pd.cut(one_phats, np.arange(0, 1.1, .1)), normalize=True, sort=False)
+            one_phat_dist = pd.Series(pd.cut(one_phats, np.arange(0, 1.1, .1))).value_counts(normalize=True, sort=False)
             logger.trace(f'Phat distribution of actual 1s ({universe}): \n{one_phat_dist.to_string()}')
             model_stats['phat_distribution_1s'] = list(one_phat_dist)
 
             zero_phats = phat_univ_df[phat_univ_df[outcome] == 0][phat_col]
-            zero_phat_dist = pd.value_counts(pd.cut(zero_phats, np.arange(0, 1.1, .1)), normalize=True, sort=False)
+            zero_phat_dist = pd.Series(pd.cut(zero_phats, np.arange(0, 1.1, .1))).value_counts(normalize=True, sort=False)
             logger.trace(f'Phat distribution of actual 0s ({universe}): \n{zero_phat_dist.to_string()}')
             model_stats['phat_distribution_0s'] = list(zero_phat_dist)
 
@@ -297,25 +361,25 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
                     phat_univ_df, threshold, phat_col, outcome, fscore_beta, weight)
 
             logger.info(f"Base rate ({universe}): {baserate}")
-            model_stats['baserate'] = float(baserate) if baserate else None
+            model_stats['baserate'] = float(baserate) if baserate is not None else None
 
             logger.info(f"Precision ({universe}): {precision}")
-            model_stats['precision'] = float(precision) if precision else None
+            model_stats['precision'] = float(precision) if precision is not None else None
 
             logger.info(f"Recall ({universe}): {recall}")
-            model_stats['recall'] = float(recall) if recall else None
+            model_stats['recall'] = float(recall) if recall is not None else None
 
             logger.info(f"False positive rate ({universe}): {fpr}")
-            model_stats['fp_rate'] = float(fpr) if fpr else None
+            model_stats['fp_rate'] = float(fpr) if fpr is not None else None
 
             logger.info(f"False negative rate ({universe}): {fnr}")
-            model_stats['fn_rate'] = float(fnr) if fnr else None
+            model_stats['fn_rate'] = float(fnr) if fnr is not None else None
 
             logger.info(f"AUC ({universe}): {auc}")
-            model_stats['auc'] = float(auc) if auc else None
+            model_stats['auc'] = float(auc) if auc is not None else None
 
             logger.info(f"F-score ({universe}): {fscore}")
-            model_stats['fscore'] = float(fscore) if fscore else None
+            model_stats['fscore'] = float(fscore) if fscore is not None else None
 
         except:
             message = f"Issue with given threshold -- not all areas of confusion matrix present ({universe})."
@@ -329,9 +393,9 @@ def evaluate_predictions(phat_df, model_type, phat_col, outcome, weight=False,
     return threshold, all_model_stats
 
 
-def evaluate_models(phats_df, outcome, model_type, weight=False, default_threshold=0.5, 
-            missingness_model_threshold_boost=0.2, optimize_threshold=False, fscore_beta=1.0, 
-            stats_dict=None):
+def evaluate_models(phats_df, outcome, model_type, weight=False, default_threshold=0.5,
+            missingness_model_threshold_boost=0.2, optimize_threshold=False, fscore_beta=1.0,
+            stats_dict=None, demographic_variables=None, all_names_df=None):
     '''Wrapper for evaluating different models (e.g. basic and no-dob) on different universes.
 
     Args:
@@ -343,6 +407,8 @@ def evaluate_models(phats_df, outcome, model_type, weight=False, default_thresho
         missingness_model_threshold_boost (float): value to add to default threshold if missingess model (use if don't find optimal)
         optimize_threshold (bool): should we find the threshold that optimizes fscore
         fscore_beta (float): ratio of recall weighting to precision weighting (e.g. 0.5 weights precision double)
+        demographic_variables (list): list of demographic/categorical variable names for subgroup analysis
+        all_names_df (pd.DataFrame): all_names dataframe with demographic columns and record_id
 
     Return:
         dict: maps model name (e.g. basic, no-dob) to thresholds (no return type)
@@ -370,7 +436,8 @@ def evaluate_models(phats_df, outcome, model_type, weight=False, default_thresho
         thresholds[model_name], \
         model_type_model_stats[model_name] = evaluate_predictions(
                 phats_to_eval_df, model_type, phat_col, outcome, weight,
-                default_threshold, missingness_model_threshold_boost, optimize_threshold, fscore_beta)
+                default_threshold, missingness_model_threshold_boost, optimize_threshold, fscore_beta,
+                demographic_variables, all_names_df)
     
     stats_dict[f"model_stats__{model_type}"] = model_type_model_stats
     if model_type == 'match':

--- a/namematch/predict.py
+++ b/namematch/predict.py
@@ -209,7 +209,7 @@ class Predict(NamematchBase):
             phat_col = f'{model_name}_{model_type}_phat'
 
             # initialize phat cols
-            phats[phat_col] = np.NaN
+            phats[phat_col] = np.nan
 
             if oob:
                 phats[phat_col] = mod.best_estimator_.named_steps['clf'].oob_decision_function_[:, MATCH_COL]

--- a/namematch/process_input_data.py
+++ b/namematch/process_input_data.py
@@ -72,7 +72,8 @@ class ProcessInputData(NamematchBase):
         data_file_list = self.schema.data_files.get_all_data_files()
 
         # store categorical variables for report
-        cat_vars = [v.name for v in self.schema.variables.varlist if v.compare_type == "Categorical"]
+        cat_vars = [v.name for v in self.schema.variables.varlist
+                    if v.compare_type in ["Categorical", "Category"]]
         self.stats_dict["categorical_variables"] = cat_vars
 
         n_an_rows = 0
@@ -296,7 +297,7 @@ class ProcessInputData(NamematchBase):
             # convert to string in python date format: e.g. 2014-05-31
             s = s.dt.strftime('%Y-%m-%d')
             s = s.replace('NaT', '')
-            s = s.replace(np.NaN, '')
+            s = s.replace(np.nan, '')
 
         elif variable.compare_type == 'Categorical' and variable.check != '':
             options = variable.check.split(',')

--- a/namematch/utils/utils.py
+++ b/namematch/utils/utils.py
@@ -531,11 +531,15 @@ def load_logging_params(logging_params_file=None):
 
 
 def reformat_dict(d: dict):
-    '''make all the string values in the yaml file have double quotes'''
+    '''make all the string values in the yaml file have double quotes and convert numpy types to Python types'''
     d = d.copy()
     for k, v in d.items():
         if isinstance(v, str):
             d[k] = DoubleQuotedScalarString(v)
+        elif isinstance(v, (np.integer, np.floating)):
+            d[k] = v.item()  # Convert numpy types to Python native types
+        elif isinstance(v, dict):
+            d[k] = reformat_dict(v)  # Recursively handle nested dicts
     return d
 
 


### PR DESCRIPTION

## What this is

A grab bag of improvements driven by running namematch end-to-end on a 7M-record dataset (the CLUE Maryland court records project): two real bug fixes, one scalability change that was needed to finish the run, several new observability hooks, and the docs to match. All changes are backward-compatible — nothing breaks for existing users.

## The one change that matters most

**Chunked Parquet loading in `FitModel`** (`feat(fit_model)`). The previous code loaded the entire combined data-rows parquet into RAM twice in `get_train_eval_data()`. On large jobs that's tens of GB and OOMs even on a 256 GB machine. Replaced with `pyarrow.iter_batches()` at 10M-row batches with per-batch filter/sample/concat. Same outputs, fits in memory.

## Bug fixes

- **`fix(parameters)`** — `blocking_scheme.cosine_distance` truncation was assigning to the wrong dict key (`'variable'` instead of `'variables'`). The warning was firing but the slice never took effect. 4-character typo, real fix.
- **`fix(utils)`** — `reformat_dict()` didn't recurse into nested dicts, so nested stats trees with numpy scalar values broke yaml dump in some environments. Now recurses + converts `np.integer`/`np.floating` to native Python.

## New features (all opt-in)

**Three observability hooks** that don't change behavior unless you turn them on:

1. **Cluster rejection reasons** (`feat(cluster,report)`). Today the clustering step reports just `n_invalid_clusters` — one number, no detail. With this PR, if your custom constraints file defines a module-level `rejection_reasons` counter and increments it before each `return False`, namematch picks it up and the matching report shows a sorted table of which constraint rejected what. Constraints files without the counter are unaffected.

2. **NMSLIB blocking efficiency log** (`feat(block)`). After the candidate-query loop, one summary block prints: total raw neighbors, candidates before/after dedup, acceptance rate, and per-query averages. Useful when tuning `blocking_thresholds`. First-batch raw neighbors also dumped to `details/near_neighbors_raw.parquet` for one-time debugging.

3. **Demographic-variable cap in evaluation** (`feat(model_evaluation)`). New `max_demographic_values` parameter (default 10) skips per-value universes for high-cardinality categorical variables. Zip code was the worst offender — thousands of values almost all below the 30-sample threshold, all flooding the log. Per-subgroup INFO logs are now gated so the run log stays readable; the stats still go to the matching report.

## Examples

**`chore(examples): track examples/clue_constraints.py`** — a worked reference implementation of the `rejection_reasons` hook (counter + 4 cluster-level constraints + `print_rejection_summary` helper). The kind of file you'd start from when writing your own constraints.

## Documentation

Three docs commits, all small:

- **`docs(match_setup)`** — adds a new subsection "Tracking rejection reasons (optional)" under "Creating user defined constraint functions" with the recipe and a worked example. (One follow-up commit reorders the subsection to land after the general "quick note" paragraphs so the flow reads naturally.)
- **`docs(default_constraints)`** — adds a Note block to the `is_valid_cluster()` docstring pointing at the new hook. People copy this file as a template, so the docstring is the natural surface to mention it.
- **`docs(CHANGELOG)`** — bootstraps the previously-empty `CHANGELOG.md` in Keep a Changelog format with an Unreleased entry summarizing this branch.

## Real-world validation

Run on the CLUE pipeline (7.1M input records → 1.86M unique person clusters, 12h 8m runtime on 32 workers). The chunked-load and matching-report changes were the ones that gated whether the run completed at all. The new observability gave us diagnostics without having to touch code mid-run.

## Backward compatibility

- No existing config keys change semantics.
- All new features are opt-in (require either a new constraint-file attribute or a new parameter to activate).
- The `'variable'`→`'variables'` typo fix only changes behavior for users who passed >2 cosine variables AND ignored the warning — and the original code path would have `AttributeError`'d anyway, so this is "now correctly truncates" rather than "silently changes results."